### PR TITLE
remove prepublish (and coolir update)

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,6 @@
     "build:module": "cross-env MODULE=true babel src --out-dir module --delete-dir-on-start  --extensions \".tsx,.ts,.js\"",
     "build": "npm run build:module && npm run build:main && npm run build:ts",
     "build:ts": "tsc --project ./tsconfig.json",
-    "prepublish": "npm run build",
     "prepare": "npm run build",
     "lint": "eslint .",
     "format": "eslint --fix .",


### PR DESCRIPTION
when we added `prepare` that was the new thing that deprecates `prepublish`

oh also @ebaker I took everything we did here and updated the `coolir` cli. I added a new template `tmpl-ts-react-npm`, and also updated the workspace:

- `ts-react-npm-module`: https://github.com/coolir/tmpl-ts-react-npm-module/commit/c17a80c46af174bf5d34810318665915f2360e00

- `ts-npm-module`: https://github.com/coolir/tmpl-ts-npm-module/commit/26b8474f0d00590f332a185ffd4e7b4fcf5782ed

- `yarn-workspace`: https://github.com/coolir/tmpl-yarn-workspace/commit/568b04c38a4004cae80ac45b694a28a87a353dba

this will help as we make more projects! or new modules as needed.

to get the latest 

```
npm install -g coolir@0.6.16
```