### PR TITLE
update desktop download link of Cosmostation wallet(#96)

### DIFF
--- a/packages/cosmostation/src/extension/registry.ts
+++ b/packages/cosmostation/src/extension/registry.ts
@@ -16,7 +16,7 @@ export const cosmostationExtensionInfo: Wallet = {
     },
     {
       icon: GoDesktopDownload,
-      link: 'https://cosmostation.io/wallet',
+      link: 'https://cosmostation.io/wallet/#extension',
     },
   ],
   mobileDisabled: true,

--- a/packages/cosmostation/src/wallet-connect/registry.ts
+++ b/packages/cosmostation/src/wallet-connect/registry.ts
@@ -23,7 +23,7 @@ export const cosmostationMobileInfo: Wallet = {
     },
     {
       icon: GoDesktopDownload,
-      link: 'https://cosmostation.io/wallet',
+      link: 'https://cosmostation.io/wallet/#extension',
     },
   ],
   mobileDisabled: false,


### PR DESCRIPTION
It is currently difficult to find download buttons for PC users (especially the MS Edge browser) on the website.
After discussing with Cosmo Station's CTO, it was decided that it was better to change the link.