### PR TITLE
getOfflineSignerAuto

### DIFF
--- a/packages/keplr/src/extension/client.ts
+++ b/packages/keplr/src/extension/client.ts
@@ -31,7 +31,7 @@ export class KeplrClient implements WalletClient {
   }
 
   getOfflineSigner(chainId: string) {
-    return this.client.getOfflineSigner(chainId);
+    return this.client.getOfflineSignerAuto(chainId);
   }
 
   async addChain(chainInfo: ChainRecord) {


### PR DESCRIPTION
I haven't tested this, because I found it quite hard to `yarn link` all the `cosmos-kit` packages locally, but I believe it resolves https://github.com/cosmology-tech/cosmos-kit/issues/99.

What happens is that [getOfflineSigner](https://github.com/chainapsis/keplr-wallet/blob/0b09aba66cbec365a0d923caae6a2c4ba47dc1b9/packages/provider/src/inject.ts#L461) in Keplr defaults to returning a wallet that supports Amino _and_ Direct signing. This is obviously false in the case of Ledger devices and is leading to some of the errors we've been seeing.