### PR TITLE
docs: fix `ChainConext` typo

### DIFF
--- a/packages/docs/pages/get-started.mdx
+++ b/packages/docs/pages/get-started.mdx
@@ -49,7 +49,7 @@ function CosmosApp() {
 
 Consume Provider with the corresponding hook. 
 
-- Hook [`useChain`](https://docs.cosmoskit.com/use-chain) consumes [`ChainProvider`](https://docs.cosmoskit.com/chain-provider) and returns type [`ChainContext`](https://docs.cosmoskit.com/use-chain#type-chainconext)
+- Hook [`useChain`](https://docs.cosmoskit.com/use-chain) consumes [`ChainProvider`](https://docs.cosmoskit.com/chain-provider) and returns type [`ChainContext`](https://docs.cosmoskit.com/use-chain#type-chaincontext)
 
 - Hook [`useWallet`](https://docs.cosmoskit.com/use-wallet) consumes [`WalletProvider`](https://docs.cosmoskit.com/wallet-provider) and returns type [`WalletMananger`](https://docs.cosmoskit.com/use-wallet#type---walletmanager)
 

--- a/packages/docs/pages/use-chain.mdx
+++ b/packages/docs/pages/use-chain.mdx
@@ -5,9 +5,9 @@
 - parameters:
     - **chainName**: `ChainName` ( = `string` );
 
-- return type: [**ChainConext**](#type-chainconext)
+- return type: [**ChainContext**](#type-chaincontext)
 
-## Type - ChainConext
+## Type - ChainContext
 
 ### properties
 


### PR DESCRIPTION
Fix the `ChainConext` typo in the docs and rename occurrences into `ChainContext`