### PR TITLE
Add leap keystore change event

### DIFF
--- a/wallets/leap-extension/src/extension/registry.ts
+++ b/wallets/leap-extension/src/extension/registry.ts
@@ -11,6 +11,7 @@ export const leapExtensionInfo: Wallet = {
   rejectMessage: {
     source: 'Request rejected',
   },
+  connectEventNamesOnWindow: ['leap_keystorechange'],
   downloads: [
     {
       device: 'desktop',


### PR DESCRIPTION
Add connectEventNameOnWindow in the leap-extension registry so that Cosmos-kit is in sync with account changes on leap-extension.