### PR TITLE
feat: Allow Disabling Endpoint Validation

### DIFF
--- a/packages/core/src/bases/chain-wallet.ts
+++ b/packages/core/src/bases/chain-wallet.ts
@@ -15,8 +15,8 @@ import {
   StdFee,
 } from '@cosmjs/stargate';
 import { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
-import { NameService } from '../name-service';
 
+import { NameService } from '../name-service';
 import {
   ChainRecord,
   CosmosClientType,
@@ -144,7 +144,7 @@ export class ChainWalletBase extends WalletBase {
     this.session?.update();
   }
 
-  initClient(options?: any): void | Promise<void> {
+  initClient(_options?: any): void | Promise<void> {
     throw new Error('initClient not implemented');
   }
 
@@ -207,12 +207,22 @@ export class ChainWalletBase extends WalletBase {
 
     if (
       this._rpcEndpoint &&
-      (await isValidEndpoint(this._rpcEndpoint, this.logger))
+      (await isValidEndpoint(
+        this._rpcEndpoint,
+        this.session.sessionOptions.shouldValidateEndpoint,
+        this.logger
+      ))
     ) {
       return this._rpcEndpoint;
     }
     for (const endpoint of this.rpcEndpoints || []) {
-      if (await isValidEndpoint(endpoint, this.logger)) {
+      if (
+        await isValidEndpoint(
+          endpoint,
+          this.session.sessionOptions.shouldValidateEndpoint,
+          this.logger
+        )
+      ) {
         this._rpcEndpoint = endpoint;
         this.logger?.debug('Using RPC endpoint ' + endpoint);
         return endpoint;
@@ -239,12 +249,22 @@ export class ChainWalletBase extends WalletBase {
 
     if (
       this._restEndpoint &&
-      (await isValidEndpoint(this._restEndpoint, this.logger))
+      (await isValidEndpoint(
+        this._restEndpoint,
+        this.session.sessionOptions.shouldValidateEndpoint,
+        this.logger
+      ))
     ) {
       return this._restEndpoint;
     }
     for (const endpoint of this.restEndpoints || []) {
-      if (await isValidEndpoint(endpoint, this.logger)) {
+      if (
+        await isValidEndpoint(
+          endpoint,
+          this.session.sessionOptions.shouldValidateEndpoint,
+          this.logger
+        )
+      ) {
         this._restEndpoint = endpoint;
         this.logger?.debug('Using REST endpoint ' + endpoint);
         return endpoint;

--- a/packages/core/src/types/manager.ts
+++ b/packages/core/src/types/manager.ts
@@ -28,12 +28,23 @@ export interface ViewOptions {
 
 export interface StorageOptions {
   disabled?: boolean;
-  duration?: number; // ms
+  /**
+   * Duration in ms.
+   */
+  duration?: number;
   clearOnTabClose?: boolean;
 }
 
 export interface SessionOptions {
-  duration: number; // ms
+  /**
+   * Duration in ms.
+   */
+  duration: number;
+  /**
+   * Disable endpoint validation when signing or broadcasting a transaction.
+   * @default true
+   */
+  shouldValidateEndpoint?: boolean;
   callback?: () => void;
 }
 

--- a/packages/core/src/utils/endpoint.ts
+++ b/packages/core/src/utils/endpoint.ts
@@ -1,10 +1,17 @@
 import { HttpEndpoint } from '@cosmjs/cosmwasm-stargate';
+
 import { Logger } from './logger';
 
 export const isValidEndpoint = async (
   endpoint: string | HttpEndpoint,
+  shouldValidate: boolean,
   logger?: Logger
 ): Promise<boolean> => {
+  if (!shouldValidate) {
+    logger?.debug('Skipping test of accessibility for', endpoint);
+    return true;
+  }
+
   logger?.debug('Testing accessibility of', endpoint);
   try {
     let response: Response;


### PR DESCRIPTION
## Changes

Allows disabling endpoint validation to avoid long waiting times before signing a transaction. Currently, the application enforces strict endpoint validation for outgoing transactions, which can lead to extended wait times for users when signing transactions.

## Motivation

At [Osmosis](https://github.com/osmosis-labs/osmosis-frontend), we are using in-house RPC/Rest endpoints. Since we have control of our endpoints, we would like to be able to sign/broadcast transactions without undergoing a 200 ms delay per transaction. 
