### PR TITLE
FIX: Show correct address based on the desired chain on Station

### DIFF
--- a/wallets/station-extension/src/extension/client.ts
+++ b/wallets/station-extension/src/extension/client.ts
@@ -19,7 +19,7 @@ export class StationClient implements WalletClient {
     return {
       namespace: 'cosmos',
       chainId,
-      address: account.address,
+      address: account.addresses[chainId],
     };
   }
 


### PR DESCRIPTION
Station is currently showing the terra address no matter which chain is selected, this PR should fix it.