### PR TITLE
fix: Get Correct Station Address by Chain ID

### DIFF
--- a/wallets/station-extension/src/extension/client.ts
+++ b/wallets/station-extension/src/extension/client.ts
@@ -19,7 +19,7 @@ export class StationClient implements WalletClient {
     return {
       namespace: 'cosmos',
       chainId,
-      address: account.addresses[chainId],
+      address: account.address,
     };
   }
 
@@ -44,7 +44,7 @@ export class StationClient implements WalletClient {
     }
 
     return {
-      address: account.address,
+      address: account.addresses[chainId],
       algo: 'secp256k1',
       pubkey: fromBase64(accountPubkey),
     };


### PR DESCRIPTION
## Description

Fixes getting wallet address by chain id from station wallet. The current version throws an error since `account.addresses` is not defined 