### PR TITLE
Update run-tests.yml for node lts

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: node
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/*'
+          node-version: 16.14.0
       - name: deps
         run: yarn
       - name: bootstrap

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.0
+          node-version: 'lts/*'
       - name: deps
         run: yarn
       - name: bootstrap

--- a/wallets/station-extension/package.json
+++ b/wallets/station-extension/package.json
@@ -92,7 +92,7 @@
     "@babel/runtime": "7.11.2",
     "@chain-registry/types": "0.13.1",
     "@cosmos-kit/core": "^1.4.0",
-    "@terra-money/feather.js": "^1.0.0-beta.14",
+    "@terra-money/feather.js": "^1.0.4",
     "@terra-money/wallet-types": "^3.11.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
hope syntax ok, this (should) fix 

`> error @terra-money/feather.js@1.0.3: 
The engine "node" is incompatible with this module. Expected version ">=18". Got "16.14.0"`

as defined by feather.js package.json now >=18, build and ship failing