### PR TITLE
feat: Throw Error When Connecting Wallet

### DIFF
--- a/packages/core/src/bases/chain-wallet.ts
+++ b/packages/core/src/bases/chain-wallet.ts
@@ -26,9 +26,9 @@ import {
   Wallet,
 } from '../types';
 import {
+  getFastestEndpoint,
   getIsLazy,
   getNameServiceRegistryFromChainName,
-  getFastestEndpoint,
   isValidEndpoint,
 } from '../utils';
 import { WalletBase } from './wallet';
@@ -162,8 +162,9 @@ export class ChainWalletBase extends WalletBase {
       } catch (error) {
         if (this.rejectMatched(error as Error)) {
           this.setRejected();
-          return;
+          throw error;
         }
+
         if (this.client.addChain) {
           await this.client.addChain(this.chainRecord);
           account = await this.client.getSimpleAccount(this.chainId);
@@ -182,6 +183,7 @@ export class ChainWalletBase extends WalletBase {
       } else {
         this.setError(e as Error);
       }
+      throw e;
     }
     if (!this.isWalletRejected) {
       window?.localStorage.setItem(

--- a/packages/core/src/bases/wallet.ts
+++ b/packages/core/src/bases/wallet.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-console */
+import EventEmitter from 'events';
+
 import {
   Callbacks,
   DownloadInfo,
@@ -11,7 +13,6 @@ import {
 } from '../types';
 import { ClientNotExistError, RejectedError, Session } from '../utils';
 import { StateBase } from './state';
-import EventEmitter from 'events';
 
 export abstract class WalletBase extends StateBase {
   clientMutable: Mutable<WalletClient> = { state: State.Init };
@@ -162,10 +163,11 @@ export abstract class WalletBase extends StateBase {
     await this.callbacks?.beforeConnect?.();
 
     if (this.isMobile && this.walletInfo.mobileDisabled) {
-      this.setError(
+      const error = new Error(
         'This wallet is not supported on mobile, please use desktop browsers.'
       );
-      return;
+      this.setError(error);
+      throw error;
     }
 
     if (sync) {
@@ -192,6 +194,7 @@ export abstract class WalletBase extends StateBase {
       await this.update();
     } catch (error) {
       this.setError(error as Error);
+      throw error;
     }
     await this.callbacks?.afterConnect?.();
   };


### PR DESCRIPTION
## Description

Throw errors coming from the `connect` wallet method. This will be useful to create predictable UI states while connecting a wallet. 