### PR TITLE
feat: update vectis image and methods & support for sign arbitrary and smart contract wallets

### DIFF
--- a/packages/core/src/types/wallet.ts
+++ b/packages/core/src/types/wallet.ts
@@ -2,6 +2,7 @@ import {
   AccountData,
   AminoSignResponse,
   OfflineAminoSigner,
+  StdSignature,
   StdSignDoc,
 } from '@cosmjs/amino';
 import {
@@ -22,6 +23,7 @@ export interface Key {
   readonly address: Uint8Array;
   readonly bech32Address: string;
   readonly isNanoLedger: boolean;
+  readonly isSmartContract?: boolean;
 }
 
 export interface SimpleAccount {
@@ -108,6 +110,7 @@ export type Bech32Address = string;
 export interface WalletAccount extends AccountData {
   username?: string;
   isNanoLedger?: boolean;
+  isSmartContract?: boolean;
 }
 
 export interface SignOptions {
@@ -189,6 +192,11 @@ export interface WalletClient {
     signDoc: DirectSignDoc,
     signOptions?: SignOptions
   ) => Promise<DirectSignResponse>;
+  signArbitrary?: (
+    chainId: string,
+    signer: string,
+    data: string | Uint8Array
+  ) => Promise<StdSignature>;
   getEnigmaPubKey?: (chainId: string) => Promise<Uint8Array>;
   getEnigmaTxEncryptionKey?: (
     chainId: string,

--- a/packages/core/types/types/wallet.d.ts
+++ b/packages/core/types/types/wallet.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 /// <reference types="long" />
-import { AccountData, AminoSignResponse, OfflineAminoSigner, StdSignDoc } from '@cosmjs/amino';
+import { AccountData, AminoSignResponse, OfflineAminoSigner, StdSignature, StdSignDoc } from '@cosmjs/amino';
 import { DirectSignResponse, OfflineDirectSigner, OfflineSigner } from '@cosmjs/proto-signing';
 import { SignClientTypes } from '@walletconnect/types';
 import { ChainWalletBase, MainWalletBase } from '../bases';
@@ -13,6 +13,7 @@ export interface Key {
     readonly address: Uint8Array;
     readonly bech32Address: string;
     readonly isNanoLedger: boolean;
+    readonly isSmartContract?: boolean;
 }
 export interface SimpleAccount {
     namespace: string;
@@ -134,6 +135,7 @@ export interface WalletClient {
     getOfflineSignerDirect?: (chainId: string) => OfflineDirectSigner;
     signAmino?: (chainId: string, signer: string, signDoc: StdSignDoc, signOptions?: SignOptions) => Promise<AminoSignResponse>;
     signDirect?: (chainId: string, signer: string, signDoc: DirectSignDoc, signOptions?: SignOptions) => Promise<DirectSignResponse>;
+    signArbitrary?: (chainId: string, signer: string, data: string | Uint8Array) => Promise<StdSignature>;
     getEnigmaPubKey?: (chainId: string) => Promise<Uint8Array>;
     getEnigmaTxEncryptionKey?: (chainId: string, nonce: Uint8Array) => Promise<Uint8Array>;
     enigmaEncrypt?: (chainId: string, contractCodeHash: string, msg: object) => Promise<Uint8Array>;

--- a/wallets/keplr-extension/src/extension/client.ts
+++ b/wallets/keplr-extension/src/extension/client.ts
@@ -1,5 +1,5 @@
 import { chainRegistryChainToKeplr } from '@chain-registry/keplr';
-import { StdSignDoc } from '@cosmjs/amino';
+import { StdSignature, StdSignDoc } from '@cosmjs/amino';
 import { Algo, OfflineDirectSigner } from '@cosmjs/proto-signing';
 import {
   ChainRecord,
@@ -26,10 +26,10 @@ export class KeplrClient implements WalletClient {
   async suggestToken({ chainId, tokens, type }: SuggestToken) {
     if (type === 'cw20') {
       for (const { contractAddress, viewingKey } of tokens) {
-        await this.client.suggestToken(chainId, contractAddress,  viewingKey);
+        await this.client.suggestToken(chainId, contractAddress, viewingKey);
       }
     }
-  };
+  }
 
   async getSimpleAccount(chainId: string) {
     const { address, username } = await this.getAccount(chainId);
@@ -99,6 +99,14 @@ export class KeplrClient implements WalletClient {
     signOptions?: SignOptions
   ) {
     return await this.client.signAmino(chainId, signer, signDoc, signOptions);
+  }
+
+  async signArbitrary(
+    chainId: string,
+    signer: string,
+    data: string | Uint8Array
+  ): Promise<StdSignature> {
+    return await this.client.signArbitrary(chainId, signer, data);
   }
 
   async signDirect(

--- a/wallets/keplr-extension/types/extension/client.d.ts
+++ b/wallets/keplr-extension/types/extension/client.d.ts
@@ -1,4 +1,4 @@
-import { StdSignDoc } from '@cosmjs/amino';
+import { StdSignature, StdSignDoc } from '@cosmjs/amino';
 import { Algo, OfflineDirectSigner } from '@cosmjs/proto-signing';
 import { ChainRecord, DirectSignDoc, SignOptions, SignType, SuggestToken, WalletClient } from '@cosmos-kit/core';
 import { BroadcastMode, Keplr } from '@keplr-wallet/types';
@@ -24,6 +24,7 @@ export declare class KeplrClient implements WalletClient {
     getOfflineSignerDirect(chainId: string): OfflineDirectSigner;
     addChain(chainInfo: ChainRecord): Promise<void>;
     signAmino(chainId: string, signer: string, signDoc: StdSignDoc, signOptions?: SignOptions): Promise<import("@keplr-wallet/types").AminoSignResponse>;
+    signArbitrary(chainId: string, signer: string, data: string | Uint8Array): Promise<StdSignature>;
     signDirect(chainId: string, signer: string, signDoc: DirectSignDoc, signOptions?: SignOptions): Promise<import("@keplr-wallet/types").DirectSignResponse>;
     sendTx(chainId: string, tx: Uint8Array, mode: BroadcastMode): Promise<Uint8Array>;
 }

--- a/wallets/vectis-extension/package.json
+++ b/wallets/vectis-extension/package.json
@@ -90,10 +90,11 @@
     "typescript": "4.8.3"
   },
   "dependencies": {
-    "@cosmos-kit/core": "^1.4.1",
-    "@vectis/extension-client": "0.6.0"
+    "@chain-registry/keplr": "1.8.0",
+    "@cosmos-kit/core": "^1.4.1"
   },
   "peerDependencies": {
-    "@cosmjs/amino": ">= 0.28"
+    "@cosmjs/amino": ">= 0.28",
+    "@cosmjs/proto-signing": ">= 0.28"
   }
 }

--- a/wallets/vectis-extension/src/extension/client.ts
+++ b/wallets/vectis-extension/src/extension/client.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Algo, StdSignDoc } from '@cosmjs/amino';
+import { chainRegistryChainToKeplr } from '@chain-registry/keplr';
+import { Algo, StdSignDoc, StdSignature } from '@cosmjs/amino';
 import {
+  BroadcastMode,
   ChainRecord,
   DirectSignDoc,
   ExtendedHttpEndpoint,
@@ -8,9 +10,8 @@ import {
   SignType,
   WalletClient,
 } from '@cosmos-kit/core';
-import { SignDoc } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
 
-import type { Vectis, VectisChainInfo } from './types';
+import type { Vectis } from './types';
 
 export class VectisClient implements WalletClient {
   readonly client: Vectis;
@@ -24,12 +25,12 @@ export class VectisClient implements WalletClient {
   }
 
   async getSimpleAccount(chainId: string) {
-    const { address, username } = await this.getAccount(chainId);
+    const { address, name } = await this.client.getKey(chainId);
     return {
       namespace: 'cosmos',
       chainId,
       address,
-      username,
+      username: name,
     };
   }
 
@@ -40,6 +41,7 @@ export class VectisClient implements WalletClient {
       pubkey,
       name,
       isNanoLedger,
+      isVectisAccount,
     } = await this.client.getKey(chainId);
     return {
       username: name,
@@ -47,6 +49,7 @@ export class VectisClient implements WalletClient {
       algo: algo as Algo,
       pubkey,
       isNanoLedger,
+      isSmartContract: isVectisAccount,
     };
   }
 
@@ -59,11 +62,6 @@ export class VectisClient implements WalletClient {
       default:
         return this.getOfflineSignerAmino(chainId);
     }
-    // const key = await this.getAccount(chainId);
-    // if (key.isNanoLedger) {
-    //   return this.getOfflineSignerAmino(chainId);
-    // }
-    // return this.getOfflineSignerDirect(chainId);
   }
 
   getOfflineSignerAmino(chainId: string) {
@@ -74,51 +72,25 @@ export class VectisClient implements WalletClient {
     return this.client.getOfflineSignerDirect(chainId);
   }
 
-  async addChain({ chain, name, preferredEndpoints }: ChainRecord) {
-    const firstFeeToken = chain.fees?.fee_tokens[0];
-    const rpcEndpoint =
-      preferredEndpoints?.rpc?.[0] || chain.apis?.rpc?.[0].address || '';
-    const restEndpoint =
-      preferredEndpoints?.rest?.[0] || chain.apis?.rest?.[0].address || '';
-    const chainInfo: VectisChainInfo = {
-      chainId: chain.chain_id,
-      prettyName: chain.pretty_name,
-      chainName: chain.chain_name,
-      rpcUrl:
-        typeof rpcEndpoint === 'string'
-          ? rpcEndpoint
-          : (rpcEndpoint as ExtendedHttpEndpoint).url,
+  async addChain({ chain, name, assetList, preferredEndpoints }: ChainRecord) {
+    const chainInfo = chainRegistryChainToKeplr(
+      chain,
+      assetList ? [assetList] : []
+    );
 
-      restUrl:
-        typeof restEndpoint === 'string'
-          ? restEndpoint
-          : (restEndpoint as ExtendedHttpEndpoint).url,
-
-      bech32Prefix: chain.bech32_prefix,
-      bip44: {
-        coinType: chain.slip44,
-      },
-      defaultFeeToken: firstFeeToken?.denom || '',
-      defaultGasPrice: firstFeeToken?.average_gas_price || 0,
-      testnet: chain.network_type === 'testnet',
-      stakingToken: chain.staking?.staking_tokens[0].denom || '',
-      feeTokens:
-        chain.fees?.fee_tokens.map((feeToken) => ({
-          denom: feeToken.denom,
-          coinDecimals: 6,
-        })) || [],
-      gasPriceStep: {
-        low: firstFeeToken?.low_gas_price || 0,
-        average: firstFeeToken?.average_gas_price || 0,
-        high: firstFeeToken?.low_gas_price || 0,
-      },
-    };
-    await this.client.suggestChains([chainInfo]);
-    const chains = await this.client.getSupportedChains();
-    const result = chains.some((chain) => chain.chainId === chainInfo.chainId);
-    if (!result) {
-      throw new Error(`Failed to add chain ${name}.`);
+    if (preferredEndpoints?.rest?.[0]) {
+      (chainInfo.rest as
+        | string
+        | ExtendedHttpEndpoint) = preferredEndpoints?.rest?.[0];
     }
+
+    if (preferredEndpoints?.rpc?.[0]) {
+      (chainInfo.rpc as
+        | string
+        | ExtendedHttpEndpoint) = preferredEndpoints?.rpc?.[0];
+    }
+
+    await this.client.suggestChains([chainInfo]);
   }
 
   async signAmino(
@@ -136,6 +108,18 @@ export class VectisClient implements WalletClient {
     signDoc: DirectSignDoc,
     signOptions?: SignOptions
   ) {
-    return await this.client.signDirect(signer, signDoc as SignDoc);
+    return await this.client.signDirect(signer, signDoc);
+  }
+
+  async signArbitrary(
+    chainId: string,
+    signer: string,
+    data: string | Uint8Array
+  ): Promise<StdSignature> {
+    return await this.client.signArbitrary(chainId, signer, data);
+  }
+
+  async sendTx(chainId: string, tx: Uint8Array, mode: BroadcastMode) {
+    return await this.client.sendTx(chainId, tx, mode);
   }
 }

--- a/wallets/vectis-extension/src/extension/registry.ts
+++ b/wallets/vectis-extension/src/extension/registry.ts
@@ -2,7 +2,8 @@ import { Wallet } from '@cosmos-kit/core';
 
 export const vectisExtensionInfo: Wallet = {
   name: 'vectis-extension',
-  logo: 'https://raw.githubusercontent.com/nymlab/vectis-extension/51e5bd1addf16169159038616c784a2f3c163259/src/ui/public/assets/icons/vectis_128.png',
+  logo:
+    'https://cloudflare-ipfs.com/ipfs/QmU7BdRsm936vQvawJNzxfHEuChEf8GEKUhp4ADHjV6tnp',
   prettyName: 'Vectis',
   mode: 'extension',
   mobileDisabled: true,
@@ -15,7 +16,8 @@ export const vectisExtensionInfo: Wallet = {
     {
       device: 'desktop',
       browser: 'chrome',
-      link: 'https://chrome.google.com/webstore/detail/vectis-wallet/cgkaddoglojnmfiblgmlinfaijcdpfjm',
+      link:
+        'https://chrome.google.com/webstore/detail/vectis-wallet/cgkaddoglojnmfiblgmlinfaijcdpfjm',
     },
   ],
 };

--- a/wallets/vectis-extension/src/extension/types.ts
+++ b/wallets/vectis-extension/src/extension/types.ts
@@ -1,6 +1,58 @@
 import {
-  ChainInfo as VectisChainInfo,
-  CosmosProvider as Vectis,
-} from '@vectis/extension-client/types';
+  AccountData,
+  Algo,
+  AminoSignResponse,
+  OfflineAminoSigner,
+  StdSignature,
+  StdSignDoc,
+} from '@cosmjs/amino';
+import {
+  DirectSignResponse,
+  OfflineDirectSigner,
+  OfflineSigner,
+} from '@cosmjs/proto-signing';
+import { BroadcastMode, DirectSignDoc } from '@cosmos-kit/core';
+import type { ChainInfo } from '@keplr-wallet/types';
 
-export type { Vectis, VectisChainInfo };
+export type { ChainInfo };
+export interface VectisWindow extends Window {
+  readonly vectis: {
+    readonly version: string;
+    readonly cosmos: Vectis;
+  };
+}
+
+export interface Vectis {
+  suggestChains(chainsInfo: ChainInfo[]): Promise<void>;
+  enable(chainIds: string | string[]): Promise<void>;
+  getSupportedChains(): Promise<ChainInfo[]>;
+  getKey(chainId: string): Promise<KeyInfo>;
+  getAccounts(chainId: string): Promise<AccountData[]>;
+  signAmino(signerAddress: string, doc: StdSignDoc): Promise<AminoSignResponse>;
+  signDirect(
+    signerAddress: string,
+    doc: DirectSignDoc
+  ): Promise<DirectSignResponse>;
+  signArbitrary(
+    chainId: string,
+    signerAddress: string,
+    data: string | Uint8Array
+  ): Promise<StdSignature>;
+  getOfflineSignerAmino(chainId: string): OfflineAminoSigner;
+  getOfflineSignerDirect(chainId: string): OfflineDirectSigner;
+  getOfflineSigner(chainId: string): OfflineSigner;
+  sendTx(
+    chainId: string,
+    tx: Uint8Array,
+    mode: BroadcastMode
+  ): Promise<Uint8Array>;
+}
+
+type KeyInfo = {
+  readonly name: string;
+  readonly algo: Algo;
+  readonly address: string;
+  readonly isNanoLedger: boolean;
+  readonly isVectisAccount: boolean;
+  readonly pubkey: Uint8Array;
+};

--- a/wallets/vectis-extension/src/extension/utils.ts
+++ b/wallets/vectis-extension/src/extension/utils.ts
@@ -1,7 +1,6 @@
 import { ClientNotExistError } from '@cosmos-kit/core';
-import { VectisWindow } from '@vectis/extension-client/types';
 
-import type { Vectis } from './types';
+import type { Vectis, VectisWindow } from './types';
 
 export const getVectisFromExtension: () => Promise<
   Vectis | undefined
@@ -10,7 +9,7 @@ export const getVectisFromExtension: () => Promise<
     return void 0;
   }
 
-  const vectis = (window as unknown as VectisWindow).vectis.cosmos;
+  const vectis = ((window as unknown) as VectisWindow).vectis.cosmos;
 
   if (vectis) {
     return vectis;

--- a/wallets/vectis-extension/types/extension/client.d.ts
+++ b/wallets/vectis-extension/types/extension/client.d.ts
@@ -1,5 +1,5 @@
-import { Algo, StdSignDoc } from '@cosmjs/amino';
-import { ChainRecord, DirectSignDoc, SignOptions, SignType, WalletClient } from '@cosmos-kit/core';
+import { Algo, StdSignDoc, StdSignature } from '@cosmjs/amino';
+import { BroadcastMode, ChainRecord, DirectSignDoc, SignOptions, SignType, WalletClient } from '@cosmos-kit/core';
 import type { Vectis } from './types';
 export declare class VectisClient implements WalletClient {
     readonly client: Vectis;
@@ -17,11 +17,14 @@ export declare class VectisClient implements WalletClient {
         algo: Algo;
         pubkey: Uint8Array;
         isNanoLedger: boolean;
+        isSmartContract: boolean;
     }>;
     getOfflineSigner(chainId: string, preferredSignType?: SignType): Promise<import("@cosmjs/amino").OfflineAminoSigner | import("@cosmjs/proto-signing").OfflineDirectSigner>;
     getOfflineSignerAmino(chainId: string): import("@cosmjs/amino").OfflineAminoSigner;
     getOfflineSignerDirect(chainId: string): import("@cosmjs/proto-signing").OfflineDirectSigner;
-    addChain({ chain, name, preferredEndpoints }: ChainRecord): Promise<void>;
+    addChain({ chain, name, assetList, preferredEndpoints }: ChainRecord): Promise<void>;
     signAmino(chainId: string, signer: string, signDoc: StdSignDoc, signOptions?: SignOptions): Promise<import("@cosmjs/amino").AminoSignResponse>;
     signDirect(chainId: string, signer: string, signDoc: DirectSignDoc, signOptions?: SignOptions): Promise<import("@cosmjs/proto-signing").DirectSignResponse>;
+    signArbitrary(chainId: string, signer: string, data: string | Uint8Array): Promise<StdSignature>;
+    sendTx(chainId: string, tx: Uint8Array, mode: BroadcastMode): Promise<Uint8Array>;
 }

--- a/wallets/vectis-extension/types/extension/types.d.ts
+++ b/wallets/vectis-extension/types/extension/types.d.ts
@@ -1,2 +1,33 @@
-import { ChainInfo as VectisChainInfo, CosmosProvider as Vectis } from '@vectis/extension-client/types';
-export type { Vectis, VectisChainInfo };
+import { AccountData, Algo, AminoSignResponse, OfflineAminoSigner, StdSignature, StdSignDoc } from '@cosmjs/amino';
+import { DirectSignResponse, OfflineDirectSigner, OfflineSigner } from '@cosmjs/proto-signing';
+import { BroadcastMode, DirectSignDoc } from '@cosmos-kit/core';
+import type { ChainInfo } from '@keplr-wallet/types';
+export type { ChainInfo };
+export interface VectisWindow extends Window {
+    readonly vectis: {
+        readonly version: string;
+        readonly cosmos: Vectis;
+    };
+}
+export interface Vectis {
+    suggestChains(chainsInfo: ChainInfo[]): Promise<void>;
+    enable(chainIds: string | string[]): Promise<void>;
+    getSupportedChains(): Promise<ChainInfo[]>;
+    getKey(chainId: string): Promise<KeyInfo>;
+    getAccounts(chainId: string): Promise<AccountData[]>;
+    signAmino(signerAddress: string, doc: StdSignDoc): Promise<AminoSignResponse>;
+    signDirect(signerAddress: string, doc: DirectSignDoc): Promise<DirectSignResponse>;
+    signArbitrary(chainId: string, signerAddress: string, data: string | Uint8Array): Promise<StdSignature>;
+    getOfflineSignerAmino(chainId: string): OfflineAminoSigner;
+    getOfflineSignerDirect(chainId: string): OfflineDirectSigner;
+    getOfflineSigner(chainId: string): OfflineSigner;
+    sendTx(chainId: string, tx: Uint8Array, mode: BroadcastMode): Promise<Uint8Array>;
+}
+declare type KeyInfo = {
+    readonly name: string;
+    readonly algo: Algo;
+    readonly address: string;
+    readonly isNanoLedger: boolean;
+    readonly isVectisAccount: boolean;
+    readonly pubkey: Uint8Array;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6394,11 +6394,6 @@
     "@typescript-eslint/types" "5.53.0"
     eslint-visitor-keys "^3.3.0"
 
-"@vectis/extension-client@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.npmjs.org/@vectis/extension-client/-/extension-client-0.6.0.tgz#17f727712040001b43c1581a3d147d7205dce30b"
-  integrity sha512-VthQXEY2vZJRPA5LRjcurgeoYAuymik0Zw2n9XpUUTGmiHLHieknCh9t/E5qF0R/4wIeOSAOL0heQITM1Lgimg==
-
 "@walletconnect/browser-utils@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz#33c10e777aa6be86c713095b5206d63d32df0951"


### PR DESCRIPTION
The previous image was broken and I include an image in IPFS and also update some methods of our extension.

Additionally I added signArbitrary method which is used for sign an arbitrary message in order to let access to your frontend for example. (https://docs.cosmos.network/v0.47/architecture/adr-036-arbitrary-signature)

I also added a new property to WalletAccount interface `isSmartContract` to let other wallet to differentiate between EOA and smart contract account.  Another suggestion for the same key could be `isSmartAccount` or in our case `isVectisAccount`

Although Keplr include an verifyArbitrary and it is a safe method, I think is frontend responsibility to do that verification without the help of the extension.