### PR TITLE
feat: Remove Icons from Leap Mobile Registry and Add Missing Dependencies for `@cosmos-kit/leap`

### DIFF
--- a/wallets/keplr-mobile/src/wallet-connect/registry.ts
+++ b/wallets/keplr-mobile/src/wallet-connect/registry.ts
@@ -3,7 +3,8 @@ import { OS, Wallet } from '@cosmos-kit/core';
 export const keplrMobileInfo: Wallet = {
   name: 'keplr-mobile',
   prettyName: 'Keplr Mobile',
-  logo: 'https://raw.githubusercontent.com/cosmology-tech/cosmos-kit/main/public/images/logos/wallets/keplr.svg',
+  logo:
+    'https://raw.githubusercontent.com/cosmology-tech/cosmos-kit/main/public/images/logos/wallets/keplr.svg',
   mode: 'wallet-connect',
   mobileDisabled: false,
   rejectMessage: {
@@ -41,7 +42,7 @@ export const keplrMobileInfo: Wallet = {
       appUrl: string,
       wcUri: string,
       os: OS | undefined,
-      name: string
+      _name: string
     ): string => {
       const plainAppUrl = appUrl.replaceAll('/', '').replaceAll(':', '');
       const encodedWcUrl = encodeURIComponent(wcUri);

--- a/wallets/leap-mobile/src/wallet-connect/registry.ts
+++ b/wallets/leap-mobile/src/wallet-connect/registry.ts
@@ -1,7 +1,4 @@
 import { OS, Wallet } from '@cosmos-kit/core';
-import { FaAndroid } from 'react-icons/fa';
-import { GoDesktopDownload } from 'react-icons/go';
-import { RiAppStoreFill } from 'react-icons/ri';
 
 export const LeapMobileInfo: Wallet = {
   name: 'leap-cosmos-mobile',
@@ -16,18 +13,15 @@ export const LeapMobileInfo: Wallet = {
     {
       device: 'mobile',
       os: 'android',
-      icon: FaAndroid,
       link:
         'https://play.google.com/store/apps/details?id=io.leapwallet.cosmos',
     },
     {
       device: 'mobile',
-      os: 'android',
-      icon: RiAppStoreFill,
+      os: 'ios',
       link: 'https://apps.apple.com/in/app/leap-cosmos/id1642465549',
     },
     {
-      icon: GoDesktopDownload,
       link:
         'https://chrome.google.com/webstore/detail/leap-cosmos-wallet/fcfcfllfndlomdhbehjjcoimbgofdncg',
     },

--- a/wallets/leap/package.json
+++ b/wallets/leap/package.json
@@ -81,7 +81,8 @@
     "typescript": "4.8.3"
   },
   "dependencies": {
-    "@cosmos-kit/leap-extension": "^0.16.4"
+    "@cosmos-kit/leap-extension": "^0.16.4",
+    "@cosmos-kit/leap-mobile": "^0.0.2"
   },
   "peerDependencies": {
     "@cosmjs/amino": ">= 0.28",


### PR DESCRIPTION
## Description

Add missing `leap-mobile` dependency in `@cosmos-kit/leap`.

Eliminate `react-icons` from the `leap-mobile` registry. It appears that these icons aren't utilized anywhere within the cosmos-kit codebase. Additionally, `react-icons` bloats the bundle size. If necessary, we could consider adding their SVGs inline.  