### PR TITLE
fix: Add Optional Chaining to Get Rest Endpoint

### DIFF
--- a/packages/core/src/bases/chain-wallet.ts
+++ b/packages/core/src/bases/chain-wallet.ts
@@ -233,7 +233,7 @@ export class ChainWalletBase extends WalletBase {
     const lazy = getIsLazy(
       void 0,
       this.isLazy,
-      (this._restEndpoint as any).isLazy,
+      (this._restEndpoint as any)?.isLazy,
       isLazy,
       this.logger
     );


### PR DESCRIPTION
### Description

This PR aims to fix an error when trying to get the rest endpoint. It adds same optional chaining operator as `getRpcEndpoint`.