### PR TITLE
(Dev UX) feat: code workspace

### DIFF
--- a/.vscode/cosmos-kit.code-workspace
+++ b/.vscode/cosmos-kit.code-workspace
@@ -1,0 +1,35 @@
+{
+  "folders": [
+    {
+      "path": "../packages/core/"
+    },
+    {
+      "path": "../packages/docs/"
+    },
+    {
+      "path": "../packages/example/"
+    },
+    {
+      "path": "../packages/ins/"
+    },
+    {
+      "path": "../packages/react/"
+    },
+    {
+      "path": "../packages/react-lite/"
+    },
+    {
+      "path": "../packages/walletconnect/"
+    },
+    {
+      "path": "../public/"
+    },
+    {
+      "path": "../wallets/"
+    },
+
+  ],
+  "settings": {
+    "jest.jestCommandLine": "yarn test"
+  }
+}


### PR DESCRIPTION
[VSCode workspaces](https://code.visualstudio.com/docs/editor/workspaces) allow first class treatment of mono repos.

Details are in the link above, but I've found it to be most beneficial for:
* Allowing extensions to treat each workspace as a root (rather than the mono repo root). This fixes many extensions that weren't built with mono repos in mind, such as the Jest extension
* Hides some of the seldom-touched files in root. Helps VSCode focus on the most important files.

To open, navigate to the `.code-workspace` file and click "Open Workspace" in the bottom right corner. VSCode will remember this workspace as though it were a folder.

<img width="299" alt="Screenshot 2023-07-03 at 10 30 19 AM" src="https://github.com/cosmology-tech/cosmos-kit/assets/4606373/abd87f3f-7e48-4f35-b3f3-4cc0856af02e">
