### PR TITLE
Fix Keplr Mobile in-app browser support

### DIFF
--- a/wallets/keplr-extension/src/extension/main-wallet.ts
+++ b/wallets/keplr-extension/src/extension/main-wallet.ts
@@ -18,6 +18,15 @@ export class KeplrExtensionWallet extends MainWalletBase {
     this.initingClient();
     try {
       const keplr = await getKeplrFromExtension();
+      // The mobile-web Keplr client exists in the Keplr Mobile in-app browser.
+      // Manually verify this here instead of setting `mobileDisabled` in the
+      // registry wallet info.
+      if (this.isMobile && keplr.mode !== 'mobile-web') {
+        throw new Error(
+          'This wallet is not supported on mobile, please use desktop browsers.'
+        );
+      }
+
       this.initClientDone(keplr ? new KeplrClient(keplr) : undefined);
     } catch (error) {
       this.initClientError(error);

--- a/wallets/keplr-extension/src/extension/main-wallet.ts
+++ b/wallets/keplr-extension/src/extension/main-wallet.ts
@@ -18,15 +18,6 @@ export class KeplrExtensionWallet extends MainWalletBase {
     this.initingClient();
     try {
       const keplr = await getKeplrFromExtension();
-      // The mobile-web Keplr client exists in the Keplr Mobile in-app browser.
-      // Manually verify this here instead of setting `mobileDisabled` in the
-      // registry wallet info.
-      if (this.isMobile && keplr.mode !== 'mobile-web') {
-        throw new Error(
-          'This wallet is not supported on mobile, please use desktop browsers.'
-        );
-      }
-
       this.initClientDone(keplr ? new KeplrClient(keplr) : undefined);
     } catch (error) {
       this.initClientError(error);

--- a/wallets/keplr-extension/src/extension/registry.ts
+++ b/wallets/keplr-extension/src/extension/registry.ts
@@ -7,7 +7,10 @@ export const keplrExtensionInfo: Wallet = {
   prettyName: 'Keplr',
   logo: ICON,
   mode: 'extension',
-  mobileDisabled: true,
+  // In the Keplr Mobile in-app browser, Keplr is available in window.keplr,
+  // similar to the extension on a desktop browser. For this reason, we must
+  // manually check what mode the window.keplr client is in on init.
+  mobileDisabled: false,
   rejectMessage: {
     source: 'Request rejected',
   },
@@ -16,8 +19,7 @@ export const keplrExtensionInfo: Wallet = {
     {
       device: 'desktop',
       browser: 'chrome',
-      link:
-        'https://chrome.google.com/webstore/detail/keplr/dmkamcknogkgcdfhhbddcghachkejeap?hl=en',
+      link: 'https://chrome.google.com/webstore/detail/keplr/dmkamcknogkgcdfhhbddcghachkejeap?hl=en',
     },
     {
       device: 'desktop',

--- a/wallets/keplr-extension/src/extension/registry.ts
+++ b/wallets/keplr-extension/src/extension/registry.ts
@@ -1,4 +1,5 @@
 import { Wallet } from '@cosmos-kit/core';
+import { Window as KeplrWindow } from '@keplr-wallet/types';
 
 import { ICON } from '../constant';
 
@@ -9,8 +10,14 @@ export const keplrExtensionInfo: Wallet = {
   mode: 'extension',
   // In the Keplr Mobile in-app browser, Keplr is available in window.keplr,
   // similar to the extension on a desktop browser. For this reason, we must
-  // manually check what mode the window.keplr client is in on init.
-  mobileDisabled: false,
+  // check what mode the window.keplr client is in once it's available.
+  mobileDisabled: () =>
+    !(
+      typeof document !== 'undefined' &&
+      document.readyState === 'complete' &&
+      (window as KeplrWindow).keplr &&
+      (window as KeplrWindow).keplr.mode === 'mobile-web'
+    ),
   rejectMessage: {
     source: 'Request rejected',
   },


### PR DESCRIPTION
The Keplr Mobile in-app browser provides `window.keplr`, similar to the extension on desktop browsers, with a `mode` set to `mobile-web`. This PR sets the `mobileDisabled` property to `false` for the Keplr extension wallet when in the context of the Keplr Mobile in-app browser.