### PR TITLE
Fix web3auth wallet tab spam

### DIFF
--- a/wallets/web3auth/src/extension/client.ts
+++ b/wallets/web3auth/src/extension/client.ts
@@ -203,9 +203,11 @@ export class Web3AuthClient implements WalletClient {
         { dontAttemptLogin: true }
       );
 
-      await client.logout({
-        cleanup: true,
-      });
+      if (client.connected) {
+        await client.logout({
+          cleanup: true,
+        });
+      }
     } catch (err) {
       console.warn('Web3Auth failed to logout:', err);
     }
@@ -215,6 +217,7 @@ export class Web3AuthClient implements WalletClient {
       terminate?.call(this.#worker);
       this.#worker = undefined;
     }
+    this.ready = false;
   }
 
   async getSimpleAccount(chainId: string) {

--- a/wallets/web3auth/src/extension/utils.ts
+++ b/wallets/web3auth/src/extension/utils.ts
@@ -10,7 +10,11 @@ import {
 } from '@web3auth/base';
 import { CommonPrivateKeyProvider } from '@web3auth/base-provider';
 import { Web3AuthNoModal } from '@web3auth/no-modal';
-import { OpenloginAdapter, UX_MODE } from '@web3auth/openlogin-adapter';
+import {
+  OpenloginAdapter,
+  OpenloginLoginParams,
+  UX_MODE,
+} from '@web3auth/openlogin-adapter';
 
 import {
   FromWorkerMessage,
@@ -157,14 +161,6 @@ export const connectClientAndProvider = async (
     privateKeyProvider,
     adapterSettings: {
       uxMode,
-      // Setting both to empty strings prevents the popup from opening when
-      // attempted, ensuring no login attempt is made. Essentially, this makes
-      // the `connectTo` method called on the client below throw an error if a
-      // session is not already logged in and cached.
-      ...(dontAttemptLogin && {
-        _startUrl: '',
-        _popupUrl: '',
-      }),
     },
   });
   client.configureAdapter(openloginAdapter);
@@ -172,11 +168,11 @@ export const connectClientAndProvider = async (
   await client.init();
 
   let provider = client.connected ? client.provider : null;
-  if (!client.connected) {
+  if (!client.connected && !dontAttemptLogin) {
     try {
       provider = await client.connectTo(WALLET_ADAPTERS.OPENLOGIN, {
         loginProvider: options.loginProvider,
-      });
+      } as OpenloginLoginParams);
     } catch (err) {
       // Unnecessary error thrown during redirect, so log and ignore it.
       if (


### PR DESCRIPTION
There is a bug in the web3auth wallet where it opens a ton of tabs randomly (when trying to disconnect in the background I think, though I can't reproduce it consistently). The disconnect logic was trying to connect first in order to disconnect. Now it should not do that.