### PR TITLE
feat: Add `signArbitrary` to OKX and Missing Sign Methods To Wallet Clients

### DIFF
--- a/wallets/cosmostation-extension/src/extension/client.ts
+++ b/wallets/cosmostation-extension/src/extension/client.ts
@@ -1,5 +1,5 @@
 import { chainRegistryChainToCosmostation } from '@chain-registry/cosmostation';
-import { StdSignDoc, StdSignature } from '@cosmjs/amino';
+import { StdSignature, StdSignDoc } from '@cosmjs/amino';
 import { OfflineDirectSigner } from '@cosmjs/proto-signing';
 import {
   BroadcastMode,
@@ -36,14 +36,14 @@ export class CosmostationClient implements WalletClient {
   async suggestToken({ chainName, tokens, type }: SuggestToken) {
     if (type === 'cw20') {
       await this.cosmos.request({
-        method: "cos_addTokensCW20",
+        method: 'cos_addTokensCW20',
         params: {
           chainName,
-          tokens
+          tokens,
         },
       });
     }
-  };
+  }
 
   async getSimpleAccount(chainId: string) {
     const { address, username } = await this.getAccount(chainId);
@@ -115,9 +115,8 @@ export class CosmostationClient implements WalletClient {
       chainInfo.assetList ? [chainInfo.assetList] : []
     );
     if (chainInfo.preferredEndpoints?.rest?.[0]) {
-      (suggestChain.restURL as
-        | string
-        | ExtendedHttpEndpoint) = chainInfo.preferredEndpoints?.rest?.[0];
+      (suggestChain.restURL as string | ExtendedHttpEndpoint) =
+        chainInfo.preferredEndpoints?.rest?.[0];
     }
     const result = (await this.cosmos.request({
       method: 'cos_addChain',
@@ -185,14 +184,15 @@ export class CosmostationClient implements WalletClient {
       return await this.ikeplr.signArbitrary(chainId, signer, data);
     } catch (error) {
       // https://github.com/cosmostation/cosmostation-chrome-extension-client/blob/main/src/cosmos.ts#LL70C17-L70C28
-      const message = typeof data === 'string' ? data : new TextDecoder('utf-8').decode(data)
+      const message =
+        typeof data === 'string' ? data : new TextDecoder('utf-8').decode(data);
       return await this.cosmos.request({
         method: 'cos_signMessage',
         params: {
           chainName: chainId,
           signer,
-          message
-        }
+          message,
+        },
       });
     }
   }

--- a/wallets/keplr-extension/src/extension/client.ts
+++ b/wallets/keplr-extension/src/extension/client.ts
@@ -43,7 +43,6 @@ export class KeplrClient implements WalletClient {
 
   async getAccount(chainId: string) {
     const key = await this.client.getKey(chainId);
-    console.log('%cclient.ts line:45 key', 'color: #007acc;', key);
     return {
       username: key.name,
       address: key.bech32Address,

--- a/wallets/okxwallet-extension/src/extension/client.ts
+++ b/wallets/okxwallet-extension/src/extension/client.ts
@@ -1,6 +1,6 @@
-import { StdSignature } from '@cosmjs/amino';
+import { StdSignature, StdSignDoc } from '@cosmjs/amino';
 import { Algo } from '@cosmjs/proto-signing';
-import { WalletClient } from '@cosmos-kit/core';
+import { DirectSignDoc, SignOptions, WalletClient } from '@cosmos-kit/core';
 
 import { Okxwallet } from './types';
 
@@ -33,6 +33,24 @@ export class OkxwalletClient implements WalletClient {
       algo: key.algo as Algo,
       pubkey: key.pubKey,
     };
+  }
+
+  async signAmino(
+    chainId: string,
+    signer: string,
+    signDoc: StdSignDoc,
+    signOptions?: SignOptions
+  ) {
+    return await this.client.signAmino(chainId, signer, signDoc, signOptions);
+  }
+
+  async signDirect(
+    chainId: string,
+    signer: string,
+    signDoc: DirectSignDoc,
+    signOptions?: SignOptions
+  ) {
+    return await this.client.signDirect(chainId, signer, signDoc, signOptions);
   }
 
   async signArbitrary(

--- a/wallets/okxwallet-extension/src/extension/client.ts
+++ b/wallets/okxwallet-extension/src/extension/client.ts
@@ -1,3 +1,4 @@
+import { StdSignature } from '@cosmjs/amino';
 import { Algo } from '@cosmjs/proto-signing';
 import { WalletClient } from '@cosmos-kit/core';
 
@@ -32,6 +33,14 @@ export class OkxwalletClient implements WalletClient {
       algo: key.algo as Algo,
       pubkey: key.pubKey,
     };
+  }
+
+  async signArbitrary(
+    chainId: string,
+    signer: string,
+    data: string | Uint8Array
+  ): Promise<StdSignature> {
+    return await this.client.signArbitrary(chainId, signer, data);
   }
 
   getOfflineSigner(chainId: string) {

--- a/wallets/okxwallet-extension/src/extension/types.ts
+++ b/wallets/okxwallet-extension/src/extension/types.ts
@@ -1,6 +1,7 @@
 import { AminoSignResponse, StdSignature, StdSignDoc } from '@cosmjs/amino';
 import { OfflineDirectSigner, OfflineSigner } from '@cosmjs/proto-signing';
 import { DirectSignResponse } from '@cosmjs/proto-signing';
+import { SignOptions } from '@cosmos-kit/core';
 import { BroadcastMode, Key, StdTx } from '@keplr-wallet/types';
 
 export interface Okxwallet {
@@ -15,7 +16,8 @@ export interface Okxwallet {
   signAmino(
     chainId: string,
     signerAddress: string,
-    signDoc: StdSignDoc
+    signDoc: StdSignDoc,
+    signOptions?: SignOptions
   ): Promise<AminoSignResponse>;
   signDirect(
     chainId: string,
@@ -29,7 +31,8 @@ export interface Okxwallet {
       chainId?: string | null;
       /** SignDoc accountNumber */
       accountNumber?: Long | null;
-    }
+    },
+    signOptions?: SignOptions
   ): Promise<DirectSignResponse>;
   signArbitrary: (
     chainId: string,

--- a/wallets/okxwallet-extension/src/extension/types.ts
+++ b/wallets/okxwallet-extension/src/extension/types.ts
@@ -1,4 +1,4 @@
-import { AminoSignResponse, StdSignDoc } from '@cosmjs/amino';
+import { AminoSignResponse, StdSignature, StdSignDoc } from '@cosmjs/amino';
 import { OfflineDirectSigner, OfflineSigner } from '@cosmjs/proto-signing';
 import { DirectSignResponse } from '@cosmjs/proto-signing';
 import { BroadcastMode, Key, StdTx } from '@keplr-wallet/types';
@@ -31,6 +31,11 @@ export interface Okxwallet {
       accountNumber?: Long | null;
     }
   ): Promise<DirectSignResponse>;
+  signArbitrary: (
+    chainId: string,
+    signer: string,
+    data: string | Uint8Array
+  ) => Promise<StdSignature>;
   sendTx(
     chainId: string,
     tx: StdTx | Uint8Array,

--- a/wallets/station-extension/src/extension/client.ts
+++ b/wallets/station-extension/src/extension/client.ts
@@ -1,4 +1,5 @@
-import { WalletClient, WalletAccount } from '@cosmos-kit/core';
+import { AminoSignResponse, StdSignDoc } from '@cosmjs/amino';
+import { SignOptions, WalletAccount, WalletClient } from '@cosmos-kit/core';
 import Station from '@terra-money/station-connector';
 
 export class StationClient implements WalletClient {
@@ -13,7 +14,7 @@ export class StationClient implements WalletClient {
   }
 
   async getSimpleAccount(chainId: string) {
-    const { name, addresses } = await this.client?.connect();
+    const { name, addresses } = await this.client.connect();
 
     const address = addresses[chainId];
 
@@ -31,15 +32,15 @@ export class StationClient implements WalletClient {
   }
 
   async getAccount(chainId: string): Promise<WalletAccount> {
-    const info = (await this.client?.info())[chainId];
+    const info = (await this.client.info())[chainId];
     if (!info)
       throw new Error(
         `The requested chainID (${chainId}) is not available, try to switch network on the Station extension.`
       );
 
-    let { name, addresses, pubkey: pubkeys } = await this.client?.connect();
+    let { name, addresses, pubkey: pubkeys } = await this.client.connect();
     if (!pubkeys) {
-      pubkeys = (await this.client?.getPublicKey()).pubkey;
+      pubkeys = (await this.client.getPublicKey()).pubkey;
     }
     const pubkey = pubkeys?.[info.coinType];
     const address = addresses[chainId];
@@ -56,6 +57,15 @@ export class StationClient implements WalletClient {
       isNanoLedger: true,
       algo: 'secp256k1',
     };
+  }
+
+  async signAmino(
+    chainId: string,
+    signer: string,
+    signDoc: StdSignDoc,
+    _signOptions?: SignOptions
+  ): Promise<AminoSignResponse> {
+    return await this.client.keplr.signAmino(chainId, signer, signDoc);
   }
 
   async getOfflineSigner(chainId: string) {

--- a/wallets/xdefi-extension/src/extension/client.ts
+++ b/wallets/xdefi-extension/src/extension/client.ts
@@ -1,4 +1,4 @@
-import { StdSignDoc, StdSignature } from '@cosmjs/amino';
+import { StdSignature, StdSignDoc } from '@cosmjs/amino';
 import { Algo, OfflineDirectSigner } from '@cosmjs/proto-signing';
 import { BroadcastMode, SignType } from '@cosmos-kit/core';
 import { DirectSignDoc, SignOptions, WalletClient } from '@cosmos-kit/core';


### PR DESCRIPTION
Add `signArbitrary` to OkxClient since it's available on its window object and Osmosis needs it to enable notifications.  

![image](https://github.com/cosmology-tech/cosmos-kit/assets/21092519/14785386-8e5d-4788-a62a-17b41908ea27)

Furthermore, add missing sign methods to individual wallets.
