### PR TITLE
fix: Cosmostation Couble Sign Pop Up

### DIFF
--- a/wallets/cosmostation-extension/src/extension/client.ts
+++ b/wallets/cosmostation-extension/src/extension/client.ts
@@ -134,9 +134,7 @@ export class CosmostationClient implements WalletClient {
     signDoc: StdSignDoc,
     signOptions?: SignOptions
   ) {
-    try {
-      return await this.ikeplr.signAmino(chainId, signer, signDoc, signOptions);
-    } catch (error) {
+    if (!this.ikeplr?.signAmino) {
       return await this.cosmos.request({
         method: 'cos_signAmino',
         params: {
@@ -147,6 +145,8 @@ export class CosmostationClient implements WalletClient {
         },
       });
     }
+
+    return await this.ikeplr.signAmino(chainId, signer, signDoc, signOptions);
   }
 
   async signDirect(
@@ -155,14 +155,7 @@ export class CosmostationClient implements WalletClient {
     signDoc: DirectSignDoc,
     signOptions?: SignOptions
   ) {
-    try {
-      return await this.ikeplr.signDirect(
-        chainId,
-        signer,
-        signDoc,
-        signOptions
-      );
-    } catch (error) {
+    if (!this.ikeplr?.signDirect) {
       return await this.cosmos.request({
         method: 'cos_signDirect',
         params: {
@@ -173,6 +166,8 @@ export class CosmostationClient implements WalletClient {
         },
       });
     }
+
+    return await this.ikeplr.signDirect(chainId, signer, signDoc, signOptions);
   }
 
   async signArbitrary(

--- a/wallets/cosmostation-extension/src/extension/client.ts
+++ b/wallets/cosmostation-extension/src/extension/client.ts
@@ -134,19 +134,19 @@ export class CosmostationClient implements WalletClient {
     signDoc: StdSignDoc,
     signOptions?: SignOptions
   ) {
-    if (!this.ikeplr?.signAmino) {
-      return await this.cosmos.request({
-        method: 'cos_signAmino',
-        params: {
-          chainName: chainId,
-          doc: signDoc,
-          isEditMemo: signOptions?.preferNoSetMemo,
-          isEditFee: signOptions?.preferNoSetFee,
-        },
-      });
+    if (this.ikeplr?.signAmino) {
+      return await this.ikeplr.signAmino(chainId, signer, signDoc, signOptions);
     }
 
-    return await this.ikeplr.signAmino(chainId, signer, signDoc, signOptions);
+    return await this.cosmos.request({
+      method: 'cos_signAmino',
+      params: {
+        chainName: chainId,
+        doc: signDoc,
+        isEditMemo: signOptions?.preferNoSetMemo,
+        isEditFee: signOptions?.preferNoSetFee,
+      },
+    });
   }
 
   async signDirect(
@@ -155,19 +155,24 @@ export class CosmostationClient implements WalletClient {
     signDoc: DirectSignDoc,
     signOptions?: SignOptions
   ) {
-    if (!this.ikeplr?.signDirect) {
-      return await this.cosmos.request({
-        method: 'cos_signDirect',
-        params: {
-          chainName: chainId,
-          doc: signDoc,
-          isEditMemo: signOptions?.preferNoSetMemo,
-          isEditFee: signOptions?.preferNoSetFee,
-        },
-      });
+    if (this.ikeplr?.signDirect) {
+      return await this.ikeplr.signDirect(
+        chainId,
+        signer,
+        signDoc,
+        signOptions
+      );
     }
 
-    return await this.ikeplr.signDirect(chainId, signer, signDoc, signOptions);
+    return await this.cosmos.request({
+      method: 'cos_signDirect',
+      params: {
+        chainName: chainId,
+        doc: signDoc,
+        isEditMemo: signOptions?.preferNoSetMemo,
+        isEditFee: signOptions?.preferNoSetFee,
+      },
+    });
   }
 
   async signArbitrary(


### PR DESCRIPTION
## Description

Refactored the `signAmino` and `signDirect` methods to check for the existence of `ikeplr` signing functions upfront. This eliminates the reliance on error-catching to determine the signing method, solving an issue where users saw two popups when rejection transactions.