### PR TITLE
fix: Station Initial Connect

### DIFF
--- a/wallets/station-extension/src/extension/utils.ts
+++ b/wallets/station-extension/src/extension/utils.ts
@@ -32,6 +32,7 @@ export const getStationFromExtension: () => Promise<
         event.target &&
         (event.target as Document).readyState === 'complete'
       ) {
+        const station = (window as StationWindow).station;
         if (station) {
           resolve(station);
         } else {


### PR DESCRIPTION
## Description

Fixed an issue with the Station wallet. On its first load, it would throw a "client not found" error because the station window property wasn't available. Additionally, the event callback was referencing an initially declared variable that was set to "undefined" due to the missing window property.