### PR TITLE
Fix wallet connect for Keplr Mobile Android

### DIFF
--- a/packages/core/src/types/wallet.ts
+++ b/packages/core/src/types/wallet.ts
@@ -91,6 +91,10 @@ export interface Wallet {
   walletconnect?: {
     name: string;
     projectId: string;
+    requiredNamespaces?: {
+      methods: string[];
+      events: string[];
+    };
     encoding?: BufferEncoding; // encoding for bytes, default 'hex'
     mobile?: AppUrl; // redirect link on mobile
     formatNativeUrl?: (

--- a/packages/walletconnect/src/client.ts
+++ b/packages/walletconnect/src/client.ts
@@ -53,6 +53,10 @@ export class WCClient implements WalletClient {
   options?: WalletConnectOptions;
   relayUrl?: string;
   env?: DappEnv;
+  requiredNamespaces?: {
+    methods: string[];
+    events: string[];
+  };
 
   constructor(walletInfo: Wallet) {
     if (!walletInfo.walletconnect) {
@@ -64,6 +68,8 @@ export class WCClient implements WalletClient {
 
     this.qrUrl = { state: State.Init };
     this.appUrl = { state: State.Init };
+
+    this.requiredNamespaces = walletInfo.walletconnect.requiredNamespaces;
   }
 
   get isMobile() {
@@ -401,9 +407,14 @@ export class WCClient implements WalletClient {
           'cosmos_getAccounts',
           'cosmos_signAmino',
           'cosmos_signDirect',
+          ...(this.requiredNamespaces?.methods ?? []),
         ],
         chains: chainIdsWithNS,
-        events: ['chainChanged', 'accountsChanged'],
+        events: [
+          'chainChanged',
+          'accountsChanged',
+          ...(this.requiredNamespaces?.methods ?? []),
+        ],
       },
     };
     let connectResp: any;

--- a/wallets/keplr-mobile/src/wallet-connect/registry.ts
+++ b/wallets/keplr-mobile/src/wallet-connect/registry.ts
@@ -51,7 +51,7 @@ export const keplrMobileInfo: Wallet = {
         case 'ios':
           return `${plainAppUrl}://wcV2?${encodedWcUrl}`;
         case 'android':
-          return `${plainAppUrl}://wcV2?${encodedWcUrl}#Intent;package=com.chainapsis.keplr;scheme=keplrwallet;end;`;
+          return `intent://wcV2?${encodedWcUrl}#Intent;package=com.chainapsis.keplr;scheme=keplrwallet;end;`;
         default:
           return `${plainAppUrl}://wcV2?${encodedWcUrl}`;
       }


### PR DESCRIPTION
Keplr Mobile Android uses `intent://` when it is a Deeplink. I attach the link below. 
https://github.com/chainapsis/keplr-wallet/blob/71f0ff84b9de8f7180847e2536f3206241ce926f/packages/wc-qrcode-modal/src/modal.tsx#L61

When communicating with Wallet connect from Keplr, we use some methods from Keplr. The related code links are below.
https://github.com/chainapsis/keplr-wallet/blob/71f0ff84b9de8f7180847e2536f3206241ce926f/packages/wc-qrcode-modal/src/index.tsx#L14

Add an option to use them.