### PR TITLE
Fix iframe autoconnect on outer wallet change

### DIFF
--- a/packages/core/src/iframe/extension/client.ts
+++ b/packages/core/src/iframe/extension/client.ts
@@ -2,6 +2,8 @@ import { StdSignature } from '@cosmjs/amino';
 
 import {
   ChainRecord,
+  IFRAME_DEFAULT_LOGO,
+  IFRAME_DEFAULT_PRETTY_NAME,
   IFRAME_PARENT_DISCONNECTED,
   SignType,
   SimpleAccount,
@@ -45,6 +47,10 @@ export class IframeClient implements WalletClient {
           iframeExtensionInfo.logo = data.response.logo;
         } else if (data.type === 'error') {
           if (data.error === IFRAME_PARENT_DISCONNECTED) {
+            // On disconnect, remove parent info.
+            iframeExtensionInfo.prettyName = IFRAME_DEFAULT_PRETTY_NAME;
+            iframeExtensionInfo.logo = IFRAME_DEFAULT_LOGO;
+
             await this.wallet.disconnect();
           }
 

--- a/packages/core/src/iframe/extension/registry.ts
+++ b/packages/core/src/iframe/extension/registry.ts
@@ -1,4 +1,6 @@
 import {
+  IFRAME_DEFAULT_LOGO,
+  IFRAME_DEFAULT_PRETTY_NAME,
   IFRAME_KEYSTORECHANGE_EVENT,
   IFRAME_WALLET_ID,
   Wallet,
@@ -6,7 +8,8 @@ import {
 
 export const iframeExtensionInfo: Wallet = {
   name: IFRAME_WALLET_ID,
-  prettyName: 'Outer Wallet',
+  prettyName: IFRAME_DEFAULT_PRETTY_NAME,
+  logo: IFRAME_DEFAULT_LOGO,
   mode: 'extension',
   mobileDisabled: false,
   rejectMessage: {

--- a/packages/core/src/iframe/extension/registry.ts
+++ b/packages/core/src/iframe/extension/registry.ts
@@ -6,7 +6,7 @@ import {
 
 export const iframeExtensionInfo: Wallet = {
   name: IFRAME_WALLET_ID,
-  prettyName: 'Iframe Parent',
+  prettyName: 'Outer Wallet',
   mode: 'extension',
   mobileDisabled: false,
   rejectMessage: {

--- a/packages/core/src/types/iframe.ts
+++ b/packages/core/src/types/iframe.ts
@@ -36,3 +36,5 @@ export type EventListenerIframeMessage = {
 export const IFRAME_WALLET_ID = 'iframe';
 export const IFRAME_KEYSTORECHANGE_EVENT = 'iframe_keystorechange';
 export const IFRAME_PARENT_DISCONNECTED = 'Outer wallet not connected.';
+export const IFRAME_DEFAULT_PRETTY_NAME = 'Outer Wallet';
+export const IFRAME_DEFAULT_LOGO = undefined;

--- a/packages/core/src/types/iframe.ts
+++ b/packages/core/src/types/iframe.ts
@@ -35,4 +35,4 @@ export type EventListenerIframeMessage = {
 
 export const IFRAME_WALLET_ID = 'iframe';
 export const IFRAME_KEYSTORECHANGE_EVENT = 'iframe_keystorechange';
-export const IFRAME_PARENT_DISCONNECTED = 'Parent wallet not connected.';
+export const IFRAME_PARENT_DISCONNECTED = 'Outer wallet not connected.';

--- a/packages/react-lite/src/hooks/useIframe.ts
+++ b/packages/react-lite/src/hooks/useIframe.ts
@@ -103,16 +103,21 @@ export const useIframe = ({
 
   // Broadcast keystore change event to iframe wallet.
   useEffect(() => {
-    if (!wallet || typeof window === 'undefined') {
-      return;
-    }
-
     const notifyIframe = () => {
       iframe?.contentWindow.dispatchEvent(
         new Event(IFRAME_KEYSTORECHANGE_EVENT)
       );
     };
 
+    // Notify inner window of keystore change on any wallet client change
+    // (likely either connection or disconnection).
+    notifyIframe();
+
+    if (!wallet || typeof window === 'undefined') {
+      return;
+    }
+
+    // Notify inner window of keystore change on any wallet connect event.
     wallet.walletInfo.connectEventNamesOnWindow?.forEach((eventName) => {
       window.addEventListener(eventName, notifyIframe);
     });
@@ -279,8 +284,9 @@ export const useIframe = ({
             // Respond with parent wallet info on successful connect.
             if (msg.type === 'success' && method === 'connect') {
               msg.response = {
-                prettyName:
-                  walletInfo?.prettyName || wallet.walletInfo.prettyName,
+                prettyName: `${
+                  walletInfo?.prettyName || wallet.walletInfo.prettyName
+                } (Outer)`,
                 logo: walletInfo?.logo || wallet.walletInfo.logo,
               };
             }


### PR DESCRIPTION
This fixes the iframe wallet not detecting the outer wallet connection change and autoconnecting/autodisconnecting where appropriate.

This also fixes the bug where the outer wallet's metadata (name and logo) would stick around after the outer wallet disconnects.