### PR TITLE
Fix iframe cross-origin messaging bug

### DIFF
--- a/packages/react-lite/src/hooks/useIframe.ts
+++ b/packages/react-lite/src/hooks/useIframe.ts
@@ -104,9 +104,9 @@ export const useIframe = ({
   // Broadcast keystore change event to iframe wallet.
   useEffect(() => {
     const notifyIframe = () => {
-      iframe?.contentWindow.dispatchEvent(
-        new Event(IFRAME_KEYSTORECHANGE_EVENT)
-      );
+      iframe?.contentWindow.postMessage({
+        event: IFRAME_KEYSTORECHANGE_EVENT,
+      });
     };
 
     // Notify inner window of keystore change on any wallet client change
@@ -139,7 +139,9 @@ export const useIframe = ({
 
   // Whenever wallet changes, broadcast keystore change event to iframe wallet.
   useEffect(() => {
-    iframe?.contentWindow.dispatchEvent(new Event(IFRAME_KEYSTORECHANGE_EVENT));
+    iframe?.contentWindow.postMessage({
+      event: IFRAME_KEYSTORECHANGE_EVENT,
+    });
   }, [wallet, iframe]);
 
   useEffect(() => {


### PR DESCRIPTION
There was a bug where the outer window controlling a nested iframe was trying to dispatch an event on the iframe, which is blocked when their origins differ. This PR fixes it by using the allowed `postMessage` function on the outer window and making the iframe window rebroadcast the message as an event internally.