### PR TITLE
fix: Race Condition When Getting Wallet When Document State Changes

### DIFF
--- a/wallets/cosmostation-extension/src/extension/utils.ts
+++ b/wallets/cosmostation-extension/src/extension/utils.ts
@@ -33,6 +33,7 @@ export const getCosmostationFromExtension: () => Promise<
         event.target &&
         (event.target as Document).readyState === 'complete'
       ) {
+        const cosmostation = (window as CosmostationWindow).cosmostation;
         if (cosmostation) {
           resolve(cosmostation);
         } else {

--- a/wallets/keplr-extension/src/extension/utils.ts
+++ b/wallets/keplr-extension/src/extension/utils.ts
@@ -28,6 +28,7 @@ export const getKeplrFromExtension: () => Promise<
         event.target &&
         (event.target as Document).readyState === 'complete'
       ) {
+        const keplr = (window as KeplrWindow).keplr;
         if (keplr) {
           resolve(keplr);
         } else {

--- a/wallets/xdefi-extension/src/extension/utils.ts
+++ b/wallets/xdefi-extension/src/extension/utils.ts
@@ -39,6 +39,7 @@ export const getXDEFIFromExtension: () => Promise<
         event.target &&
         (event.target as Document).readyState === 'complete'
       ) {
+        const xdefi = (window as XDEFIWindow)?.xfi?.keplr;
         if (xdefi) {
           resolve(xdefi);
         } else {


### PR DESCRIPTION
## Description

Fixed an issue with the Keplr, Cosmostation, and Xdefi wallet. On its first load, it would throw a "client not found" error because the station window property wasn't available. Additionally, the event callback was referencing an initially declared variable that was set to "undefined" due to the missing window property.

Similar to #314 