### PR TITLE
Fix Keplr Mobile deep link URL

### DIFF
--- a/wallets/keplr-mobile/src/wallet-connect/registry.ts
+++ b/wallets/keplr-mobile/src/wallet-connect/registry.ts
@@ -45,7 +45,7 @@ export const keplrMobileInfo: Wallet = {
       os: OS | undefined,
       _name: string
     ): string => {
-      const plainAppUrl = appUrl.replaceAll('/', '').replaceAll(':', '');
+      const plainAppUrl = appUrl.split(':')[0];
       const encodedWcUrl = encodeURIComponent(wcUri);
       switch (os) {
         case 'ios':

--- a/wallets/leap-mobile/src/wallet-connect/registry.ts
+++ b/wallets/leap-mobile/src/wallet-connect/registry.ts
@@ -46,7 +46,7 @@ export const LeapMobileInfo: Wallet = {
       os: OS | undefined,
       _name: string
     ): string => {
-      const plainAppUrl = appUrl.replaceAll('/', '').replaceAll(':', '');
+      const plainAppUrl = appUrl.split(':')[0];
       const encodedWcUrl = encodeURIComponent(wcUri);
       switch (os) {
         case 'ios':


### PR DESCRIPTION
This fixes the Keplr Mobile deep-linking on mobile. It's been broken for a while.

While the URL intent is configured correctly in the `registry.ts` walletconnect options, the WalletConnect Cloud's API response with wallet info takes precedence, which is here:
```
{
  "listings": {
    "6adb6082c909901b9e7189af3a4a0223102cd6f8d5c39e39f3d49acb92b578bb": {
      "id": "6adb6082c909901b9e7189af3a4a0223102cd6f8d5c39e39f3d49acb92b578bb",
      "name": "Keplr",
      "slug": "keplr",
      "description": "Keplr is the largest Interchain wallet in the Cosmos ecosystem, supporting ",
      "homepage": "https://keplr.app",
      "chains": [
        "cosmos:columbus-4",
        "cosmos:cosmoshub-4",
        "cosmos:irishub-1",
        "cosmos:kava-4",
        "cosmos:likecoin-mainnet-2"
      ],
      "versions": [
        "1",
        "2"
      ],
      "sdks": [
        "sign_v1",
        "sign_v2"
      ],
      "app_type": "wallet",
      "category": "Mobile Wallets",
      "image_id": "527324b0-3849-462b-9a1a-72b53bdfea00",
      "image_url": {
        "sm": "https://explorer-api.walletconnect.com/v3/logo/sm/527324b0-3849-462b-9a1a-72b53bdfea00?projectId=2021db728d55be8401efaf25f4e534cd",
        "md": "https://explorer-api.walletconnect.com/v3/logo/md/527324b0-3849-462b-9a1a-72b53bdfea00?projectId=2021db728d55be8401efaf25f4e534cd",
        "lg": "https://explorer-api.walletconnect.com/v3/logo/lg/527324b0-3849-462b-9a1a-72b53bdfea00?projectId=2021db728d55be8401efaf25f4e534cd"
      },
      "app": {
        "browser": "https://wallet.keplr.app",
        "ios": "https://apps.apple.com/us/app/keplr-wallet/id1567851089",
        "android": "https://play.google.com/store/apps/details?id=com.chainapsis.keplr&hl=en&gl=US",
        "mac": null,
        "windows": null,
        "linux": null,
        "chrome": "https://chrome.google.com/webstore/detail/keplr/dmkamcknogkgcdfhhbddcghachkejeap?hl=en",
        "firefox": "https://addons.mozilla.org/en-US/firefox/addon/keplr/",
        "safari": null,
        "edge": "https://microsoftedge.microsoft.com/addons/detail/keplr/ocodgmmffbkkeecmadcijjhkmeohinei",
        "opera": null
      },
      "injected": null,
      "rdns": null,
      "mobile": {
        "native": "keplrwallet://wcV2",
        "universal": null
      },
      "desktop": {
        "native": "",
        "universal": null
      },
      "metadata": {
        "shortName": "Keplr",
        "colors": {
          "primary": "#314FDF",
          "secondary": "#864FFC"
        }
      },
      "updatedAt": "2023-02-15T14:03:40.111519+00:00"
    }
  },
  "count": 1,
  "total": 1
}
```

The `mobile.native` field is set to `keplrwallet://wcV2`. This leads to incorrect intents that look like `keplrwalletwcV2://wcV2?wc...` when in reality we just want to grab the `keplrwallet` prefix from that URL.