### PR TITLE
Default `preferNoSetFee` to `false`

### DIFF
--- a/packages/docs/pages/get-started.mdx
+++ b/packages/docs/pages/get-started.mdx
@@ -8,7 +8,7 @@
 
 ```json
 {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/packages/docs/pages/hooks/use-chain-wallet.mdx
+++ b/packages/docs/pages/hooks/use-chain-wallet.mdx
@@ -62,7 +62,7 @@
 
 ```json
 {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/packages/docs/pages/hooks/use-chain.mdx
+++ b/packages/docs/pages/hooks/use-chain.mdx
@@ -65,7 +65,7 @@
 
 ```json
 {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/packages/walletconnect/src/client.ts
+++ b/packages/walletconnect/src/client.ts
@@ -58,7 +58,7 @@ export class WCClient implements WalletClient {
     events: string[];
   };
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/coin98-extension/src/extension/client.ts
+++ b/wallets/coin98-extension/src/extension/client.ts
@@ -16,7 +16,7 @@ import { Coin98 } from './types';
 export class Coin98Client implements WalletClient {
   readonly client: Coin98;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/compass-extension/src/extension/client.ts
+++ b/wallets/compass-extension/src/extension/client.ts
@@ -15,7 +15,7 @@ import { Compass } from './types';
 export class CompassClient implements WalletClient {
   readonly client: Compass;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/cosmos-extension-metamask/src/extension/client.ts
+++ b/wallets/cosmos-extension-metamask/src/extension/client.ts
@@ -14,7 +14,7 @@ import { SignDoc } from '@keplr-wallet/types';
 export class CosmosExtensionClient implements WalletClient {
   cosmos: CosmosSnap;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/cosmostation-extension/src/extension/client.ts
+++ b/wallets/cosmostation-extension/src/extension/client.ts
@@ -21,7 +21,7 @@ export class CosmostationClient implements WalletClient {
     Map<EventListenerOrEventListenerObject, Event>
   > = new Map();
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/fin-extension/src/extension/client.ts
+++ b/wallets/fin-extension/src/extension/client.ts
@@ -16,7 +16,7 @@ import { Fin } from './types';
 export class FinClient implements WalletClient {
   readonly client: Fin;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/frontier-extension/src/extension/client.ts
+++ b/wallets/frontier-extension/src/extension/client.ts
@@ -8,7 +8,7 @@ import { Frontier } from './types';
 export class FrontierClient implements WalletClient {
   readonly client: Frontier;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/keplr-extension/src/extension/client.ts
+++ b/wallets/keplr-extension/src/extension/client.ts
@@ -15,7 +15,7 @@ import { BroadcastMode, Keplr } from '@keplr-wallet/types';
 export class KeplrClient implements WalletClient {
   readonly client: Keplr;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/leap-extension/src/extension/client.ts
+++ b/wallets/leap-extension/src/extension/client.ts
@@ -15,7 +15,7 @@ import { Leap } from './types';
 export class LeapClient implements WalletClient {
   readonly client: Leap;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/leap-metamask-cosmos-snap/src/extension/client.ts
+++ b/wallets/leap-metamask-cosmos-snap/src/extension/client.ts
@@ -26,7 +26,7 @@ import Long from 'long';
 export class CosmosSnapClient implements WalletClient {
   readonly snapInstalled: boolean = false;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/okxwallet-extension/src/extension/client.ts
+++ b/wallets/okxwallet-extension/src/extension/client.ts
@@ -7,7 +7,7 @@ import { Okxwallet } from './types';
 export class OkxwalletClient implements WalletClient {
   readonly client: Okxwallet;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/shell-extension/src/extension/client.ts
+++ b/wallets/shell-extension/src/extension/client.ts
@@ -17,7 +17,7 @@ import { Shell } from './types';
 export class ShellClient implements WalletClient {
   readonly client: Shell;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };

--- a/wallets/xdefi-extension/src/extension/client.ts
+++ b/wallets/xdefi-extension/src/extension/client.ts
@@ -8,7 +8,7 @@ import { XDEFI } from './types';
 export class XDEFIClient implements WalletClient {
   readonly client: XDEFI;
   private _defaultSignOptions: SignOptions = {
-    preferNoSetFee: true,
+    preferNoSetFee: false,
     preferNoSetMemo: true,
     disableBalanceCheck: true,
   };


### PR DESCRIPTION
This changes the `preferNoSetFee` flag default to `false` for all wallets.

I noticed this was added and defaulted to `true` in https://github.com/cosmology-tech/cosmos-kit/commit/af1cbac3588f50f250fa65fc4fba9fda2844689a, but I don't understand why. I believe this is going to break most dApps, requiring them to manually call `wallet.client.setDefaultSignOptions({ preferNoSetFee: false })` for the connected wallet every time if they want fees to be selected (right now this default is requiring the user to manually choose a fee in Keplr). This is unexpected behavior and not a sensible default as far as I can tell.

If I'm misunderstanding something, please let me know 🙏