### PR TITLE
Allow infinite iframe recursion

### DIFF
--- a/packages/core/src/iframe/extension/main-wallet.ts
+++ b/packages/core/src/iframe/extension/main-wallet.ts
@@ -15,7 +15,7 @@ export class IframeWallet extends MainWalletBase {
   async initClient() {
     this.initingClient();
 
-    if (window.top === window.self) {
+    if (window.parent === window.self) {
       this.initClientError(
         new Error('This wallet must be used inside of an iframe.')
       );

--- a/packages/core/src/iframe/extension/utils.ts
+++ b/packages/core/src/iframe/extension/utils.ts
@@ -61,7 +61,7 @@ export const sendAndListenOnce = <T>(
 
     try {
       // Send the message to our parent.
-      window.top.postMessage(
+      window.parent.postMessage(
         {
           ...message,
           id,

--- a/packages/core/src/manager.ts
+++ b/packages/core/src/manager.ts
@@ -80,7 +80,7 @@ export class WalletManager extends StateBase {
     // Add iframe wallet to beginning of wallet list unless not in iframe or
     // iframe is disabled.
     wallets = [
-      ...((typeof window !== 'undefined' && window.top === window.self) ||
+      ...((typeof window !== 'undefined' && window.parent === window.self) ||
       disableIframe
         ? []
         : [iframeWallet]),
@@ -332,7 +332,7 @@ export class WalletManager extends StateBase {
   private _restoreAccounts = async () => {
     const walletName =
       // If in an iframe and not disabled, default to the iframe wallet.
-      !this.disableIframe && window.top !== window.self
+      !this.disableIframe && window.parent !== window.self
         ? IFRAME_WALLET_ID
         : window.localStorage.getItem('cosmos-kit@2:core//current-wallet');
     if (walletName) {
@@ -390,7 +390,7 @@ export class WalletManager extends StateBase {
     // different origin (and it most likely is), it cannot dispatch events on
     // our (the iframe's) window. Thus, it posts a message with the event name
     // to our window and we broadcast it.
-    if (!this.disableIframe && window.top !== window.self) {
+    if (!this.disableIframe && window.parent !== window.self) {
       window.addEventListener('message', this._handleIframeKeystoreChangeEvent);
     }
 
@@ -444,7 +444,7 @@ export class WalletManager extends StateBase {
     }
 
     // If in iframe, stop listening for keystore change event.
-    if (!this.disableIframe && window.top !== window.self) {
+    if (!this.disableIframe && window.parent !== window.self) {
       window.removeEventListener(
         'message',
         this._handleIframeKeystoreChangeEvent


### PR DESCRIPTION
## What

This fixes the iframe implementation so that it allows for infinite recursion of iframes. Instead of using `window.top`, which always points to the outermost window, the iframe should be exchanging messages with its parent window, `window.parent`. This replaces `window.top` references with `window.parent`, which ensures a double or more-nested iframe still works.

## Why

Just because this is how it should work, architecturally, and not because it needs to work this way.
