### PR TITLE
Export useIframe hook from cosmos-kit react

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -11,6 +11,7 @@ export {
   useChain,
   useChains,
   useChainWallet,
+  useIframe,
   useManager,
   useNameService,
   useWallet,


### PR DESCRIPTION
The `useIframe` hook was not re-exported in the full react version of cosmos-kit.