### PR TITLE
Don't treat non-existent wallets as if they were connected

### DIFF
--- a/packages/core/src/bases/state.ts
+++ b/packages/core/src/bases/state.ts
@@ -90,9 +90,7 @@ export class StateBase {
   }
 
   get isWalletOnceConnect() {
-    return (
-      this.isWalletConnected || this.isWalletNotExist || this.isWalletError
-    );
+    return this.isWalletConnected || this.isWalletError;
   }
 
   get isWalletConnecting() {

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -97,7 +97,9 @@ export class WalletRepo extends StateBase {
       );
       return void 0;
     }
-    return this.wallets.find((w) => !w.isWalletDisconnected);
+    return this.wallets.find(
+      (w) => !w.isWalletNotExist && !w.isWalletDisconnected
+    );
   }
 
   getWallet = (walletName: WalletName): ChainWalletBase | undefined => {


### PR DESCRIPTION
All non-existent wallets immediately enter NotExist state on init. Because of that, I think it needs to stop treating non-existent wallets as if they were once connected or are the current wallet. I'm not exactly sure how, but I think `current` being stuck on a non-existent wallet is preventing other wallets from connecting, and this seems to fix it.