### PR TITLE
fix: installed wallets detection

### DIFF
--- a/packages/core/src/bases/state.ts
+++ b/packages/core/src/bases/state.ts
@@ -96,9 +96,7 @@ export class StateBase {
   }
 
   get isWalletOnceConnect() {
-    return (
-      this.isWalletConnected || this.isWalletNotExist || this.isWalletError
-    );
+    return this.isWalletConnected || this.isWalletError;
   }
 
   get isWalletConnecting() {

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -157,7 +157,9 @@ export class WalletRepo extends StateBase {
       );
       return void 0;
     }
-    return this.wallets.find((w) => !w.isWalletDisconnected);
+    return this.wallets.find(
+      (w) => !w.isWalletNotExist && !w.isWalletDisconnected
+    );
   }
 
   getWallet = (walletName: WalletName): ChainWalletBase | undefined => {


### PR DESCRIPTION
## Proposed changes

- Avoid setting wallets with `walletStatus === 'NotExist'` as current. If Cosmostaion is not installed, `CosmostationClient` sets this status right after init. This prevents some other wallets (e.g. Leap) from connecting.
- Remove `isWalletNotExist` from `isWalletOnceConnect` to align with the changes above.