### PR TITLE
feat: add Metamask detection to leap-metamask-cosmos-snap

### DIFF
--- a/wallets/leap-metamask-cosmos-snap/src/extension/main-wallet.ts
+++ b/wallets/leap-metamask-cosmos-snap/src/extension/main-wallet.ts
@@ -3,6 +3,7 @@ import { MainWalletBase } from '@cosmos-kit/core';
 
 import { ChainMetamaskCosmosSnap } from './chain-wallet';
 import { CosmosSnapClient } from './client';
+import { isMetamaskInstalled } from './utils';
 
 export class MetamaskCosmosSnapWallet extends MainWalletBase {
   constructor(walletInfo: Wallet) {
@@ -12,9 +13,9 @@ export class MetamaskCosmosSnapWallet extends MainWalletBase {
   async initClient() {
     this.initingClient();
     try {
-      this.initClientDone(new CosmosSnapClient());
+      const installed = await isMetamaskInstalled();
+      this.initClientDone(installed ? new CosmosSnapClient() : undefined);
     } catch (error) {
-      this.logger?.error(error);
       this.initClientError(error);
     }
   }

--- a/wallets/leap-metamask-cosmos-snap/src/extension/utils.ts
+++ b/wallets/leap-metamask-cosmos-snap/src/extension/utils.ts
@@ -1,0 +1,45 @@
+import { ClientNotExistError } from '@cosmos-kit/core';
+
+interface MetamaskWindow {
+  ethereum?: {
+    isMetamask?: boolean;
+  };
+}
+
+export const isMetamaskInstalled: () => Promise<boolean> = async () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const ethereum = (window as MetamaskWindow).ethereum;
+
+  if (ethereum?.isMetamask) {
+    return true;
+  }
+
+  if (document.readyState === 'complete') {
+    if (ethereum?.isMetamask) {
+      return true;
+    } else {
+      throw ClientNotExistError;
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const documentStateChange = (event: Event) => {
+      if (
+        event.target &&
+        (event.target as Document).readyState === 'complete'
+      ) {
+        if (ethereum?.isMetamask) {
+          resolve(true);
+        } else {
+          reject(ClientNotExistError.message);
+        }
+        document.removeEventListener('readystatechange', documentStateChange);
+      }
+    };
+
+    document.addEventListener('readystatechange', documentStateChange);
+  });
+};


### PR DESCRIPTION
## Proposed changes

- Add Metamask detection to `leap-metamask-cosmos-snap`, so that custom modals can detect that Metamask is installed, similar to other wallets like Keplr, Cosmostation, Leap.