### PR TITLE
fix: Leap Metamask Snaps signDirect - cannot read properties of undefined 'authInfoBytes' issue

### DIFF
--- a/wallets/leap-metamask-cosmos-snap/src/extension/client.ts
+++ b/wallets/leap-metamask-cosmos-snap/src/extension/client.ts
@@ -21,7 +21,6 @@ import {
   requestSignature,
 } from '@leapwallet/cosmos-snap-provider';
 import { SignDoc } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
-
 import Long from 'long';
 
 export class CosmosSnapClient implements WalletClient {
@@ -112,11 +111,11 @@ export class CosmosSnapClient implements WalletClient {
     signDoc: DirectSignDoc
   ): Promise<DirectSignResponse> {
     const _accountNumber = Long.fromString(signDoc.accountNumber.toString());
-    const signature = requestSignature(chainId, signer, {
+    const signature = (await requestSignature(chainId, signer, {
       ...signDoc,
       // @ts-ignore
       accountNumber: _accountNumber,
-    }) as unknown as DirectSignResponse;
+    })) as unknown as DirectSignResponse;
 
     const modifiedAccountNumber = new Long(
       _accountNumber!.low,


### PR DESCRIPTION
**Issue:** 
When calling signDirect on Leap Cosmos Metamask Snaps (v0.6.1), we are getting following error:
`TypeError: Cannot read properties of undefined (reading 'authInfoBytes')
    at CosmosSnapClient.signDirect`

**Cause:** 
There should be `await` in this [line](https://github.com/cosmology-tech/cosmos-kit/blob/efbf059a79454b2a7992f63b8ea3d4f21d7d6634/wallets/leap-metamask-cosmos-snap/src/extension/client.ts#L115).
`requestSignature` from ['@leapwallet/cosmos-snap-provider'](https://github.com/leapwallet/cosmos-metamask-snap/blob/6abebb540c72a1fcec05922bae9142b77c730ea0/packages/cosmos-snap-provider/src/snap.ts#L130) is an async function.

**Fix:**
Add `await` before `requestSignature`. 