### PR TITLE
Move @chain-registry/types package imports to peer dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,7 +74,6 @@
   },
   "dependencies": {
     "@chain-registry/client": "^1.18.0",
-    "@chain-registry/types": "0.17.0",
     "@cosmjs/amino": "^0.32.3",
     "@cosmjs/cosmwasm-stargate": "^0.32.3",
     "@cosmjs/proto-signing": "^0.32.3",
@@ -85,6 +84,12 @@
     "cosmjs-types": "^0.9.0",
     "events": "3.3.0",
     "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "@chain-registry/types": "^0.17.0"
+  },
+  "peerDependencies": {
+    "@chain-registry/types": ">= 0.17"
   },
   "gitHead": "2b5f2de5d9ed1580be4137736dfc6cce779679d1"
 }

--- a/packages/react-lite/package.json
+++ b/packages/react-lite/package.json
@@ -75,11 +75,11 @@
     ]
   },
   "devDependencies": {
+    "@chain-registry/types": "^0.17.0",
     "@types/react": "^18.2",
     "@types/react-dom": "^18.2"
   },
   "dependencies": {
-    "@chain-registry/types": "0.17.0",
     "@cosmos-kit/core": "^2.9.3",
     "@dao-dao/cosmiframe": "^0.0.4"
   },
@@ -87,6 +87,9 @@
     "@types/react": "^18.2"
   },
   "peerDependencies": {
+    "@chain-registry/types": ">= 0.17",
+    "@types/react": ">= 17",
+    "@types/react-dom": ">= 17",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -75,11 +75,11 @@
     ]
   },
   "devDependencies": {
+    "@chain-registry/types": "^0.17.0",
     "@types/react": "^18.2",
     "@types/react-dom": "^18.2"
   },
   "dependencies": {
-    "@chain-registry/types": "0.17.0",
     "@cosmos-kit/core": "^2.9.3",
     "@cosmos-kit/react-lite": "^2.7.3",
     "@react-icons/all-files": "^4.1.0"
@@ -88,7 +88,10 @@
     "@types/react": "^18"
   },
   "peerDependencies": {
+    "@chain-registry/types": ">= 0.17",
     "@interchain-ui/react": "^1.23.9",
+    "@types/react": ">= 17",
+    "@types/react-dom": ">= 17",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/wallets/station-extension/package.json
+++ b/wallets/station-extension/package.json
@@ -60,13 +60,16 @@
     ]
   },
   "dependencies": {
-    "@chain-registry/types": "0.17.0",
     "@cosmos-kit/core": "^2.9.3",
     "@terra-money/feather.js": "^1.0.8",
     "@terra-money/station-connector": "^1.1.0",
     "@terra-money/wallet-types": "^3.11.2"
   },
+  "devDependencies": {
+    "@chain-registry/types": "^0.17.0"
+  },
   "peerDependencies": {
+    "@chain-registry/types": ">= 0.17",
     "@cosmjs/amino": ">=0.32.3",
     "@cosmjs/proto-signing": ">=0.32.3"
   },

--- a/wallets/web3auth/package.json
+++ b/wallets/web3auth/package.json
@@ -57,7 +57,6 @@
     ]
   },
   "dependencies": {
-    "@chain-registry/types": "0.17.0",
     "@cosmos-kit/core": "^2.9.3",
     "@solana/web3.js": "^1.77.3",
     "@toruslabs/eccrypto": "^2.1.1",
@@ -70,7 +69,11 @@
     "ethereum-cryptography": "^2.1.2",
     "url": "^0.11.1"
   },
+  "devDependencies": {
+    "@chain-registry/types": "^0.17.0"
+  },
   "peerDependencies": {
+    "@chain-registry/types": ">= 0.17",
     "@cosmjs/amino": "^0.32.3",
     "@cosmjs/proto-signing": "^0.32.3",
     "@keplr-wallet/cosmos": ">= 0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1191,13 +1191,6 @@
     "@keplr-wallet/crypto" "0.12.28"
     semver "^7.5.0"
 
-"@chain-registry/types@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.npmjs.org/@chain-registry/types/-/types-0.17.0.tgz"
-  integrity sha512-lavACU4oDxioUy8lZOFZN0Vrr2qR+Dg2yEh/mkrPfOldcioavREXJou0elDyyXwq4pGLC5YQ+IISCtQ4Du0bdw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
-
 "@chain-registry/types@^0.17.0", "@chain-registry/types@^0.17.1":
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/@chain-registry/types/-/types-0.17.1.tgz#0ac7bda6178d3917834578627f232a247fe5def8"


### PR DESCRIPTION
Don't force clients to use an old version of @chain-registry packages.