### PR TITLE
Fix `kelpr-extension` impoting

### DIFF
--- a/wallets/keplr-extension/src/extension/index.ts
+++ b/wallets/keplr-extension/src/extension/index.ts
@@ -1,4 +1,3 @@
 export * from './chain-wallet';
 export * from './main-wallet';
 export * from './registry';
-export * from './utils';


### PR DESCRIPTION
I deleted the `utils` directory from https://github.com/cosmology-tech/cosmos-kit/pull/460 PR and forgot to delete the import.