### PR TITLE
Add check connectable session before connect to mobile on `Keplr Mobile`

### DIFF
--- a/wallets/keplr-mobile/src/wallet-connect/client.ts
+++ b/wallets/keplr-mobile/src/wallet-connect/client.ts
@@ -77,6 +77,21 @@ export class KeplrClient extends WCClient {
     const pairing = this.pairing;
     this.logger?.debug('Restored active pairing topic is:', pairing?.topic);
 
+    // If the pairing topic is already set, try to connect to the session
+    if (this.signClient && pairing?.topic) {
+      const allSessions = this.signClient.session.getAll();
+      const currentSession = allSessions.find(
+        (session) => session.pairingTopic === pairing.topic
+      );
+
+      if (allSessions.length > 0 && currentSession) {
+        this.initKeplrWCClient(this.signClient, {
+          sessionProperties: currentSession.sessionProperties,
+        });
+        return;
+      }
+    }
+
     if (this.displayQRCode) this.setQRState(State.Pending);
 
     const requiredNamespaces = {


### PR DESCRIPTION
### Overview
When connecting the `Keplr Mobile` wallet with `Wallect Connect`, I set it to connect to an `existing session` if one exists.

### Reasons for the change
For examples, proceed to the example source in cosmos-kit.
1. The connection works fine when there are no sessions.
[![first connect]()](https://github.com/cosmology-tech/cosmos-kit/assets/32606183/d5bf7ec5-9be8-47c2-9d79-db99530af784)
2. However, if you refresh the page after connecting, it will request connect multiple times due to the source below in the `packages/react-lite/src/hooks/useChain.ts` file.
```typescript
// temporary solution for sync not working when the used chain is changed without page rendering (only component rendering)
  useEffect(() => {
    const currentWallet = window.localStorage.getItem(
      'cosmos-kit@2:core//current-wallet'
    );
    if (
      sync &&
      chainWalletContext &&
      chainWalletContext.isWalletDisconnected &&
      currentWallet
    ) {
      connect(currentWallet);
    }
  }, [chain, assetList]);
```
3. Ask the app to confirm the connection via wallect connect `signClinet.connect`.
4. You'll see multiple requests, as shown below.
[![try to connect]()](https://github.com/cosmology-tech/cosmos-kit/assets/32606183/15564f83-4329-40c6-b133-7f2dfd2dc3eb)

### What changed.
 - Always create `initKeplrWCClient` after connecting via `Keplr Mobile`, instead of creating `initKeplrWCClient` with an existing `session` if one exists
 - I've implemented session restore in our DApp in the documentation below
https://docs.walletconnect.com/api/sign/dapp-usage#restoring-a-session