### PR TITLE
fix: properly check if metamask is installed

### DIFF
--- a/wallets/cosmos-extension-metamask/src/extension/main-wallet.ts
+++ b/wallets/cosmos-extension-metamask/src/extension/main-wallet.ts
@@ -3,6 +3,7 @@ import { MainWalletBase } from '@cosmos-kit/core';
 
 import { ChainCosmosExtensionMetamaskSnap } from './chain-wallet';
 import { CosmosExtensionClient } from './client';
+import { isMetamaskInstalled } from './utils';
 
 export class CosmosMetamaskExtensionWallet extends MainWalletBase {
   constructor(walletInfo: Wallet) {
@@ -12,7 +13,8 @@ export class CosmosMetamaskExtensionWallet extends MainWalletBase {
   async initClient() {
     this.initingClient();
     try {
-      this.initClientDone(new CosmosExtensionClient());
+      const installed = await isMetamaskInstalled();
+      this.initClientDone(installed ? new CosmosExtensionClient() : undefined);
     } catch (error) {
       this.initClientError(error);
     }

--- a/wallets/cosmos-extension-metamask/src/extension/utils.ts
+++ b/wallets/cosmos-extension-metamask/src/extension/utils.ts
@@ -1,15 +1,36 @@
 import { ClientNotExistError } from '@cosmos-kit/core';
 import { CosmosSnap } from '@cosmsnap/snapper';
 
+interface MetamaskWindow {
+  ethereum?: {
+    isMetaMask?: boolean;
+  };
+}
+
 interface SnapWindow {
   cosmos?: CosmosSnap;
 }
+
+export const isMetamaskInstalled = async (): Promise<boolean> => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const ethereum = (window as MetamaskWindow).ethereum;
+  return Boolean(ethereum?.isMetaMask);
+};
 
 export const getSnapProviderFromExtension: () => Promise<
   CosmosSnap | undefined
 > = async () => {
   if (typeof window === 'undefined') {
     return void 0;
+  }
+
+  // Check if MetaMask is installed first
+  const hasMetaMask = await isMetamaskInstalled();
+  if (!hasMetaMask) {
+    throw ClientNotExistError;
   }
 
   const cosmos = (window as SnapWindow).cosmos;


### PR DESCRIPTION
## ISSUE
The cosmos-extension-metamask wallet does not properly check if metamask is installed or not. 

## SUMMARY
In the Leap metamask snap extension we properly check for the metamask window  with

```
interface MetamaskWindow {
  ethereum?: {
    isMetaMask?: boolean;
  };
}

export const isMetamaskInstalled: () => Promise<boolean> = async () => {
  if (typeof window === 'undefined') {
    return false;
  }

  const ethereum = (window as MetamaskWindow).ethereum;

  if (ethereum?.isMetaMask) {
    return true;
  }

  if (document.readyState === 'complete') {
    if (ethereum?.isMetaMask) {
      return true;
    } else {
      throw ClientNotExistError;
    }
  }
  ```
  
  But in the cosmos-extension we do not 
  
  ```
  interface SnapWindow {
  cosmos?: CosmosSnap;
}

export const getSnapProviderFromExtension: () => Promise<
  CosmosSnap | undefined
> = async () => {
  if (typeof window === 'undefined') {
    return void 0;
  }

  const cosmos = (window as SnapWindow).cosmos;

  if (cosmos) {
    return cosmos;
  }

  if (document.readyState === 'complete') {
    if (cosmos) {
      return cosmos;
    } else {
      throw ClientNotExistError;
    }
  }
  ```
  
