### PR TITLE
fix: throw notexist error when !Keplr

### DIFF
--- a/wallets/keplr-extension/src/extension/main-wallet.ts
+++ b/wallets/keplr-extension/src/extension/main-wallet.ts
@@ -1,4 +1,4 @@
-import { EndpointOptions, Wallet } from '@cosmos-kit/core';
+import { ClientNotExistError, EndpointOptions, Wallet } from '@cosmos-kit/core';
 import { MainWalletBase } from '@cosmos-kit/core';
 import { Keplr } from '@keplr-wallet/provider-extension';
 
@@ -18,7 +18,10 @@ export class KeplrExtensionWallet extends MainWalletBase {
     this.initingClient();
     try {
       const keplr = await Keplr.getKeplr();
-      this.initClientDone(keplr ? new KeplrClient(keplr) : undefined);
+      if (!keplr) {
+        throw ClientNotExistError;
+      }
+      this.initClientDone(new KeplrClient(keplr));
     } catch (error) {
       this.initClientError(error);
     }


### PR DESCRIPTION
## ISSUE
Keplr isnt throwing ClientNotExist which doesnt set isWalletExist

## SUMMARY

We import Keplr winow controls which have proper checks but we dont set ClientNotExistError's on the cosmoskit side which causes isWalletNotExist to return false when it doesnt exist

Ive added 

```
async initClient() {
    this.initingClient();
    try {
      const keplr = await Keplr.getKeplr();
      if (!keplr) {
        throw ClientNotExistError;
      }
      this.initClientDone(new KeplrClient(keplr));
    } catch (error) {
      this.initClientError(error);
    }
  }
}
```
Which fixes the problem and properly sets the error state when Keplr doesnt exist
