### PR TITLE
improve iframe functionality

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.32.3",
     "@cosmjs/proto-signing": "^0.32.3",
     "@cosmjs/stargate": "^0.32.3",
-    "@dao-dao/cosmiframe": "^0.1.0",
+    "@dao-dao/cosmiframe": "^1.0.0-rc.1",
     "@walletconnect/types": "2.11.0",
     "bowser": "2.11.0",
     "cosmjs-types": "^0.9.0",

--- a/packages/core/src/cosmiframe/cosmiframe.ts
+++ b/packages/core/src/cosmiframe/cosmiframe.ts
@@ -1,6 +1,8 @@
+import { Origin } from '@dao-dao/cosmiframe';
+
 import { cosmiframeExtensionInfo, CosmiframeWallet } from './extension';
 
-export const makeCosmiframeWallet = (allowedParentOrigins: string[]) =>
+export const makeCosmiframeWallet = (allowedParentOrigins: Origin[]) =>
   new CosmiframeWallet({
     ...cosmiframeExtensionInfo,
     allowedParentOrigins,

--- a/packages/core/src/cosmiframe/extension/types.ts
+++ b/packages/core/src/cosmiframe/extension/types.ts
@@ -1,5 +1,7 @@
+import { Origin } from '@dao-dao/cosmiframe';
+
 import { Wallet } from '../../types';
 
 export type CosmiframeWalletInfo = Wallet & {
-  allowedParentOrigins: string[];
+  allowedParentOrigins: Origin[];
 };

--- a/packages/core/src/manager.ts
+++ b/packages/core/src/manager.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type { AssetList, Chain } from '@chain-registry/types';
-import { isInIframe } from '@dao-dao/cosmiframe';
+import { isInIframe, Origin } from '@dao-dao/cosmiframe';
 import Bowser from 'bowser';
 import EventEmitter from 'events';
 
@@ -52,7 +52,13 @@ export class WalletManager extends StateBase {
     logger: Logger,
     throwErrors: boolean | 'connect_only',
     subscribeConnectEvents = true,
-    allowedCosmiframeParentOrigins?: string[],
+    allowedCosmiframeParentOrigins: Origin[] = [
+      /^https?:\/\/localhost(:\d+)?/,
+      /^https:\/\/(.+\.)?osmosis\.zone/,
+      /^https:\/\/(.+\.)?daodao\.zone/,
+      /^https:\/\/.+-da0da0\.vercel\.app/,
+      /^https:\/\/(.+\.)?abstract\.money/,
+    ],
     assetLists?: AssetList[],
     defaultNameService?: NameServiceName,
     walletConnectOptions?: WalletConnectOptions,
@@ -87,8 +93,8 @@ export class WalletManager extends StateBase {
     ];
     wallets.forEach(
       ({ walletName }) =>
-      (this._reconnectMap[walletName] = () =>
-        this._reconnect(walletName, true))
+        (this._reconnectMap[walletName] = () =>
+          this._reconnect(walletName, true))
     );
     this.init(
       chains,

--- a/packages/react-lite/package.json
+++ b/packages/react-lite/package.json
@@ -80,7 +80,7 @@
   "dependencies": {
     "@chain-registry/types": "^0.46.11",
     "@cosmos-kit/core": "^2.15.0",
-    "@dao-dao/cosmiframe": "^0.1.0"
+    "@dao-dao/cosmiframe": "^1.0.0-rc.1"
   },
   "resolutions": {
     "@types/react": "^18.2"

--- a/packages/react-lite/src/provider.tsx
+++ b/packages/react-lite/src/provider.tsx
@@ -15,6 +15,7 @@ import {
   WalletModalProps,
   WalletRepo,
 } from '@cosmos-kit/core';
+import { Origin } from '@dao-dao/cosmiframe';
 import { createContext, ReactNode, useEffect, useMemo, useState } from 'react';
 
 export const walletContext = createContext<{
@@ -35,16 +36,7 @@ export function ChainProvider({
   endpointOptions,
   sessionOptions,
   logLevel = 'WARN',
-  allowedIframeParentOrigins = [
-    'http://localhost:3000',
-    'https://localhost:3000',
-    'https://app.osmosis.zone',
-    'https://daodao.zone',
-    'https://dao.daodao.zone',
-    'https://my.abstract.money',
-    'https://apps.abstract.money',
-    'https://console.abstract.money',
-  ],
+  allowedIframeParentOrigins,
   children,
 }: {
   chains: (Chain | ChainName)[];
@@ -63,9 +55,9 @@ export function ChainProvider({
    * Origins to allow wrapping this app in an iframe and connecting to this
    * Cosmos Kit instance.
    *
-   * Defaults to Osmosis and DAO DAO.
+   * Defaults to localhost, Osmosis, DAO DAO, and Abstract.
    */
-  allowedIframeParentOrigins?: string[];
+  allowedIframeParentOrigins?: Origin[];
   children: ReactNode;
 }) {
   const logger = useMemo(() => new Logger(logLevel), []);
@@ -143,10 +135,10 @@ export function ChainProvider({
   }, []);
 
   useEffect(() => {
-    walletManager && walletManager.onMounted();
+    walletManager?.onMounted();
     return () => {
       setViewOpen(false);
-      walletManager && walletManager.onUnmounted();
+      walletManager?.onUnmounted();
     };
   }, [render, walletManager]);
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -76,7 +76,8 @@
   },
   "devDependencies": {
     "@types/react": "^18.2",
-    "@types/react-dom": "^18.2"
+    "@types/react-dom": "^18.2",
+    "@dao-dao/cosmiframe": "^1.0.0-rc.1"
   },
   "dependencies": {
     "@chain-registry/types": "^0.46.11",

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -13,11 +13,12 @@ import {
   WalletModalProps,
 } from '@cosmos-kit/core';
 import { ChainProvider as ChainProviderLite } from '@cosmos-kit/react-lite';
+import { Origin } from '@dao-dao/cosmiframe';
 import { ReactNode, useCallback, useMemo } from 'react';
 
+import { SelectedWalletRepoProvider } from './context';
 import { ThemeCustomizationProps, WalletModal } from './modal';
 import { defaultModalViews } from './modal/components/views';
-import { SelectedWalletRepoProvider } from './context';
 
 export const ChainProvider = ({
   chains,
@@ -33,16 +34,7 @@ export const ChainProvider = ({
   endpointOptions,
   sessionOptions,
   logLevel = 'WARN',
-  allowedIframeParentOrigins = [
-    'http://localhost:3000',
-    'https://localhost:3000',
-    'https://app.osmosis.zone',
-    'https://daodao.zone',
-    'https://dao.daodao.zone',
-    'https://my.abstract.money',
-    'https://apps.abstract.money',
-    'https://console.abstract.money'
-  ],
+  allowedIframeParentOrigins,
   children,
   modalTheme = {},
   modalOptions,
@@ -64,9 +56,9 @@ export const ChainProvider = ({
    * Origins to allow wrapping this app in an iframe and connecting to this
    * Cosmos Kit instance.
    *
-   * Defaults to Osmosis and DAO DAO.
+   * Defaults to Osmosis, DAO DAO, and Abstract.
    */
-  allowedIframeParentOrigins?: string[];
+  allowedIframeParentOrigins?: Origin[];
   children: ReactNode;
   modalTheme?: ThemeCustomizationProps;
   modalOptions?: ModalOptions;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,10 +1581,10 @@
     node-appwrite "^14.0.0"
     ses "^0.18.4"
 
-"@dao-dao/cosmiframe@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@dao-dao/cosmiframe/-/cosmiframe-0.1.0.tgz#5ba241d0c14a45d62df60cff7d48ba26844ebeac"
-  integrity sha512-NW4pGt1ctqDfhn/A6RU2vwnFEu3O4aBNnBMrGnw31n+L35drYNEsA9ZB7KZsHmRRlkNx+jSuJSv2Fv0BFBDDJQ==
+"@dao-dao/cosmiframe@^1.0.0-rc.1":
+  version "1.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@dao-dao/cosmiframe/-/cosmiframe-1.0.0-rc.1.tgz#51d4d1801605b8abfd01ae0425c797b6b876991e"
+  integrity sha512-XftJPwbqgS1RWg9SUNBI58vTGnjINZ995OYRwDuUZ6CsuENS2DifAzqgzDgdac+0o5Hqvy/5Aq+HN1Jl/dptTw==
   dependencies:
     uuid "^9.0.1"
 
@@ -18024,16 +18024,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18149,7 +18140,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18176,13 +18167,6 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -19739,7 +19723,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19752,15 +19736,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This adds the following to the `useIframe` hook:
- return a function to trigger the iframe wallet keystore change event so that the calling app can inform the nested iframe app that wallet details have changed
- return the iframe instance so that the caller can interact directly with the saved iframe ref, avoiding the need to save duplicates

This also updates to the latest Cosmiframe, to enable chain ID specific signer overrides as well as regex origins.