### PR TITLE
fix: ledger wallet

### DIFF
--- a/wallets/ledger/package.json
+++ b/wallets/ledger/package.json
@@ -66,12 +66,14 @@
   },
   "dependencies": {
     "@cosmos-kit/core": "^2.15.1",
-    "@ledgerhq/hw-app-cosmos": "^6.28.1",
-    "@ledgerhq/hw-transport-webhid": "^6.27.15",
-    "@ledgerhq/hw-transport-webusb": "^6.27.15"
+    "@ledgerhq/hw-app-cosmos": "^6.30.4",
+    "@ledgerhq/hw-transport-webhid": "^6.30.0",
+    "@ledgerhq/hw-transport-webusb": "^6.29.4"
   },
   "peerDependencies": {
-    "@cosmjs/amino": ">=0.32.3",
-    "@cosmjs/proto-signing": ">=0.32.3"
+    "@cosmjs/amino": ">=0.32.4",
+    "@cosmjs/crypto": ">=0.32.4",
+    "@cosmjs/encoding": ">=0.32.4",
+    "@cosmjs/proto-signing": ">=0.32.4"
   }
 }

--- a/wallets/ledger/src/index.ts
+++ b/wallets/ledger/src/index.ts
@@ -1,3 +1,3 @@
+export * from './constant';
 export * from './ledger';
 export * from './web-usb-hid/registry';
-export * from './constant';

--- a/wallets/ledger/src/web-usb-hid/chain-wallet.ts
+++ b/wallets/ledger/src/web-usb-hid/chain-wallet.ts
@@ -1,6 +1,6 @@
 import { ChainRecord, ChainWalletBase, Wallet } from '@cosmos-kit/core';
 
-export class LedgerChianWallet extends ChainWalletBase {
+export class LedgerChainWallet extends ChainWalletBase {
   constructor(walletInfo: Wallet, chainInfo: ChainRecord) {
     super(walletInfo, chainInfo);
   }

--- a/wallets/ledger/src/web-usb-hid/main-wallet.ts
+++ b/wallets/ledger/src/web-usb-hid/main-wallet.ts
@@ -1,6 +1,6 @@
-import { EndpointOptions, Wallet } from '@cosmos-kit/core';
-import { MainWalletBase } from '@cosmos-kit/core';
-import { LedgerChianWallet } from './chain-wallet';
+import { EndpointOptions, MainWalletBase, Wallet } from '@cosmos-kit/core';
+
+import { LedgerChainWallet } from './chain-wallet';
 import { LedgerClient } from './client';
 import { TransportType } from './utils';
 
@@ -11,7 +11,7 @@ export class LedgerMainWallet extends MainWalletBase {
     preferredEndpoints?: EndpointOptions['endpoints'],
     transportType: TransportType = 'WebUSB'
   ) {
-    super(walletInfo, LedgerChianWallet);
+    super(walletInfo, LedgerChainWallet);
     this.preferredEndpoints = preferredEndpoints;
     this.transportType = transportType;
   }

--- a/wallets/ledger/src/web-usb-hid/registry.ts
+++ b/wallets/ledger/src/web-usb-hid/registry.ts
@@ -1,4 +1,5 @@
 import { Wallet } from '@cosmos-kit/core';
+
 import { ICON } from '../constant';
 
 export const LedgerInfo: Wallet = {

--- a/wallets/ledger/src/web-usb-hid/utils.ts
+++ b/wallets/ledger/src/web-usb-hid/utils.ts
@@ -1,25 +1,25 @@
-import { chains } from 'chain-registry'
-import Cosmos from "@ledgerhq/hw-app-cosmos";
+import Cosmos from '@ledgerhq/hw-app-cosmos';
+import TransportWebHID from '@ledgerhq/hw-transport-webhid';
 import TransportWebUSB from '@ledgerhq/hw-transport-webusb';
-import TransportWebHID from '@ledgerhq/hw-transport-webhid'
+import { chains } from 'chain-registry';
 
-export type TransportType = 'WebUSB' | 'WebHID'
+export type TransportType = 'WebUSB' | 'WebHID';
 
 export async function getCosmosApp(type: TransportType = 'WebUSB') {
   if (type === 'WebUSB') {
-    return new Cosmos(await TransportWebUSB.create())
+    return new Cosmos(await TransportWebUSB.create());
   }
   if (type === 'WebHID') {
-    return new Cosmos(await TransportWebHID.create())
+    return new Cosmos(await TransportWebHID.create());
   }
-  throw new Error(`Unknown transport type: ${type}`)
+  throw new Error(`Unknown transport type: ${type}`);
 }
 
 export function getCosmosPath(accountIndex = 0) {
-  return `44'/118'/${accountIndex}'/0/0`
+  return `44'/118'/${accountIndex}'/0/0`;
 }
 
-export const ChainIdToBech32Prefix = {} as { [k: string]: string }
+export const ChainIdToBech32Prefix = {} as { [k: string]: string };
 for (const chain of chains) {
-  ChainIdToBech32Prefix[chain.chain_id] = chain.bech32_prefix
+  ChainIdToBech32Prefix[chain.chain_id] = chain.bech32_prefix;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18024,7 +18024,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18140,7 +18149,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18167,6 +18176,13 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -19723,7 +19739,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19736,6 +19752,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
- Fixes the missing `getOfflineSigner` implementation
- Fixes `StdSignDoc` serialization to JSON. The object MUST be serialized in lexicographical key order [1]
- Replace the encoding of `pubkey` in `getAccount` from a `TextEncoder` to using the `fromHex` function
- Bump `@ledgerhq/*` dependencies
- Prettify

Fixes #497 

[1]: https://github.com/cosmos/ledger-cosmos/blob/main/docs/TXSPEC.md#validation