### PR TITLE
Fix typo: @comos-kit to @cosmos-kit in walletconnectOptions docs

### DIFF
--- a/docs/provider/chain-provider.mdx
+++ b/docs/provider/chain-provider.mdx
@@ -106,7 +106,7 @@ In addition, you can integrate new wallets in a few steps.
 
 ### walletconnectOptions
 
-Required when `mobile` wallets dependent on `@comos-kit/walletconnect`(implements walletconnect v2 connection) are added in [`wallets`](#wallets).
+Required when `mobile` wallets dependent on `@cosmos-kit/walletconnect`(implements walletconnect v2 connection) are added in [`wallets`](#wallets).
 
 **Type:** `WalletConnectOptions`
 


### PR DESCRIPTION
## Summary
- Fixed typo in `docs/provider/chain-provider.mdx`
- Changed `@comos-kit/walletconnect` to `@cosmos-kit/walletconnect`

## Test plan
- [x] Verify the typo is corrected in the documentation