### PR TITLE
Fix grammar in advanced.md documentation

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -2,7 +2,7 @@
 
 ## Code Structure
 
-To make user better understand the whole design structure of CosmosKit, here to briefly introduce some important classes from `@cosmos-kit/core`.
+To help users better understand the whole design structure of CosmosKit, here we briefly introduce some important classes from `@cosmos-kit/core`.
 
 There are four important classes.
 


### PR DESCRIPTION
## Summary
- Fixed grammar in `docs/advanced.md`
- Changed "To make user better understand" to "To help users better understand"
- Changed "here to briefly introduce" to "here we briefly introduce"

## Test plan
- [x] Verify the grammar is corrected in the documentation