### PR TITLE
Fix typo: ManagerConext to ManagerContext in use-manager.mdx

### DIFF
--- a/docs/hooks/use-manager.mdx
+++ b/docs/hooks/use-manager.mdx
@@ -2,9 +2,9 @@
 
 - required provider: [**ChainProvider**](../provider/chain-provider) from either `@cosmos-kit/react` or `@cosmos-kit/react-lite`
 
-- return type: [**ManagerConext**](#type---managerconext)
+- return type: [**ManagerContext**](#type---managerconext)
 
-## Type - ManagerConext
+## Type - ManagerContext
 
 ### properties
 


### PR DESCRIPTION
## Summary
- Fixed typo in `docs/hooks/use-manager.mdx`
- Changed "ManagerConext" to "ManagerContext" (missing 't' in Context)

## Test plan
- [x] Verify the typo is corrected in the documentation