### PR TITLE
Fix grammar in web3auth.mdx documentation

### DIFF
--- a/docs/integrating-wallets/web3auth.mdx
+++ b/docs/integrating-wallets/web3auth.mdx
@@ -1,6 +1,6 @@
 # How to Add Web3Auth Wallet to CosmosKit
 
-> ### Note! This package is still on progress. it doesn't work on mobile yet and it's pretty vulnerable to XSS attacks.
+> ### Note! This package is still in progress. It doesn't work on mobile yet and it's pretty vulnerable to XSS attacks.
 
 There is one package for web3auth
 


### PR DESCRIPTION
## Summary
- Fixed grammar in `docs/integrating-wallets/web3auth.mdx`
- Changed "still on progress" to "still in progress"
- Capitalized "it" to "It" at the start of the sentence

## Test plan
- [x] Verify the grammar is corrected in the documentation