### PR TITLE
Fix grammar: lighter to lighten in get-started.mdx

### DIFF
--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -28,7 +28,7 @@ Taking `Keplr` wallet as an example.
 yarn add @cosmos-kit/react @cosmos-kit/keplr chain-registry
 ```
 
-`@cosmos-kit/react` includes default modal made with `@interchain-ui/react`. If [customized modal](./provider/chain-provider/#customize-modal-with-walletmodal) is provided, you can use `@cosmos-kit/react-lite` instead to lighter your app.
+`@cosmos-kit/react` includes default modal made with `@interchain-ui/react`. If [customized modal](./provider/chain-provider/#customize-modal-with-walletmodal) is provided, you can use `@cosmos-kit/react-lite` instead to lighten your app.
 
 There are multiple wallets supported by CosmosKit. Details see [Integrating Wallets](./integrating-wallets)
 


### PR DESCRIPTION
## Summary
- Fixed grammar in `docs/get-started.mdx`
- Changed "to lighter your app" to "to lighten your app" (lighter is an adjective/noun, lighten is the verb)

## Test plan
- [x] Verify the grammar is corrected in the documentation