### PR TITLE
docs: update READMEs to reference pnpm instead of yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ See our docs on [integrating your wallet](https://docs.hyperweb.io/cosmos-kit/in
 For high-level examples suitable for most developers, explore our [create-cosmos-app](https://github.com/hyperweb-io/create-cosmos-app). For a deeper, more technical understanding, this repository contains an example, which is also useful when integrating new wallets.
 
 ```sh
-yarn build
+pnpm run build
 cd packages/example
-yarn dev
+pnpm dev
 ```
 
 #### [Basic Next.js Example](https://github.com/hyperweb-io/cosmos-kit/tree/main/examples)
@@ -141,19 +141,19 @@ This example is ideal for developers looking to create integrations for Vue.js, 
 
 ## 🛠 Developing
 
-Checkout the repository and bootstrap the yarn workspace:
+Checkout the repository and bootstrap the pnpm workspace:
 
 ```sh
 # Clone the repo.
 git clone https://github.com/hyperweb-io/cosmos-kit
 cd cosmos-kit
-yarn
+pnpm install
 ```
 
 ### Building
 
 ```sh
-yarn build
+pnpm run build
 ```
 
 ### Publishing

--- a/examples/cosmos-kit-nextjs-app-router-example/README.md
+++ b/examples/cosmos-kit-nextjs-app-router-example/README.md
@@ -5,13 +5,7 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 First, run the development server:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
 pnpm dev
-# or
-bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/examples/cosmos-kit-nextjs-pages-router-example/README.md
+++ b/examples/cosmos-kit-nextjs-pages-router-example/README.md
@@ -3,9 +3,7 @@
 First, run the development server:
 
 ```bash
-npm run dev
-# or
-yarn dev
+pnpm dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/packages/cosmos-kit/README.md
+++ b/packages/cosmos-kit/README.md
@@ -117,9 +117,9 @@ See our docs on [integrating your wallet](https://docs.hyperweb.io/cosmos-kit/in
 For high-level examples suitable for most developers, explore our [create-cosmos-app](https://github.com/hyperweb-io/create-cosmos-app). For a deeper, more technical understanding, this repository contains an example, which is also useful when integrating new wallets.
 
 ```sh
-yarn build
+pnpm run build
 cd packages/example
-yarn dev
+pnpm dev
 ```
 
 #### [Basic Next.js Example](https://github.com/hyperweb-io/cosmos-kit/tree/main/packages/example)
@@ -139,19 +139,19 @@ This example is ideal for developers looking to create integrations for Vue.js, 
 
 ## 🛠 Developing
 
-Checkout the repository and bootstrap the yarn workspace:
+Checkout the repository and bootstrap the pnpm workspace:
 
 ```sh
 # Clone the repo.
 git clone https://github.com/hyperweb-io/cosmos-kit
 cd cosmos-kit
-yarn
+pnpm install
 ```
 
 ### Building
 
 ```sh
-yarn build
+pnpm run build
 ```
 
 ### Publishing

--- a/packages/react-lite/README.md
+++ b/packages/react-lite/README.md
@@ -34,7 +34,7 @@ Cosmos Kit is a universal wallet adapter for developers to build apps that quick
 ## Installation
 
 ```sh
-yarn add @cosmos-kit/react @cosmos-kit/core @cosmos-kit/keplr chain-registry
+pnpm add @cosmos-kit/react @cosmos-kit/core @cosmos-kit/keplr chain-registry
 ```
 
 ## Provider

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -34,7 +34,7 @@ Cosmos Kit is a universal wallet adapter for developers to build apps that quick
 ## Installation
 
 ```sh
-yarn add @cosmos-kit/react @cosmos-kit/core @cosmos-kit/keplr chain-registry
+pnpm add @cosmos-kit/react @cosmos-kit/core @cosmos-kit/keplr chain-registry
 ```
 
 ## Provider


### PR DESCRIPTION
# docs: update READMEs to reference pnpm instead of yarn

## Summary

Follow-up to #595 (yarn → pnpm migration). Updates all README files that still referenced `yarn` commands to use `pnpm` equivalents.

**6 files changed:**
- `README.md` — `yarn` / `yarn build` → `pnpm install` / `pnpm run build`
- `packages/cosmos-kit/README.md` — same as above
- `packages/react/README.md` — `yarn add` → `pnpm add`
- `packages/react-lite/README.md` — `yarn add` → `pnpm add`
- `examples/cosmos-kit-nextjs-pages-router-example/README.md` — simplified to `pnpm dev`
- `examples/cosmos-kit-nextjs-app-router-example/README.md` — simplified to `pnpm dev`

## Review & Testing Checklist for Human

- [ ] Verify no other files in the repo still reference `yarn` (e.g. CONTRIBUTING.md, wiki, or inline code comments) — a quick `grep -r "yarn" --include="*.md"` should confirm

### Notes

Link to Devin run: https://app.devin.ai/sessions/470239005b9b4c909a5eaf94cd127fce
Requested by: @pyramation